### PR TITLE
Fix iOS Brave crash: guard mediaDevices and add legacy getUserMedia fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "vite-scaffold",
+  "name": "whisperprompt",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-scaffold",
+      "name": "whisperprompt",
       "version": "0.0.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "html5-qrcode": "^2.3.8",
         "marked": "^18.0.0",
@@ -918,9 +919,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,9 +936,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -958,9 +953,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -978,9 +970,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -998,9 +987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1018,9 +1004,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1247,9 +1230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1247,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1287,9 +1264,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1307,9 +1281,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,9 +3193,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3246,9 +3214,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3270,9 +3235,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3294,9 +3256,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -11,11 +11,30 @@ export interface AudioRecorderService {
 const MAX_DURATION_MS = 5 * 60 * 1000
 
 function getSupportedMimeType(): string {
-  const types = ['audio/webm;codecs=opus', 'audio/webm', 'audio/wav']
+  if (typeof MediaRecorder === 'undefined') {
+    throw new Error('Audio recording is not supported in this browser.')
+  }
+  const types = ['audio/mp4', 'audio/aac', 'audio/webm;codecs=opus', 'audio/webm', 'audio/wav']
   for (const type of types) {
     if (MediaRecorder.isTypeSupported(type)) return type
   }
-  return 'audio/webm'
+  throw new Error('No supported audio format found in this browser.')
+}
+
+function getMediaStream(): Promise<MediaStream> {
+  if (navigator.mediaDevices?.getUserMedia) {
+    return navigator.mediaDevices.getUserMedia({ audio: true })
+  }
+  const legacyGetUserMedia =
+    (navigator as any).getUserMedia ||
+    (navigator as any).webkitGetUserMedia ||
+    (navigator as any).mozGetUserMedia
+  if (legacyGetUserMedia) {
+    return new Promise((resolve, reject) => {
+      legacyGetUserMedia.call(navigator, { audio: true }, resolve, reject)
+    })
+  }
+  throw new Error('Microphone access is not available in this browser.')
 }
 
 export function createAudioRecorder(): AudioRecorderService {
@@ -33,9 +52,9 @@ export function createAudioRecorder(): AudioRecorderService {
 
   const service: AudioRecorderService = {
     async start() {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-      chunks = []
       const mimeType = getSupportedMimeType()
+      const stream = await getMediaStream()
+      chunks = []
       mediaRecorder = new MediaRecorder(stream, { mimeType })
       mediaRecorder.ondataavailable = (e) => {
         if (e.data.size > 0) chunks.push(e.data)


### PR DESCRIPTION
navigator.mediaDevices is undefined in some iOS/Brave contexts. Add a
getMediaStream() helper that falls back to the legacy webkit-prefixed API,
and update getSupportedMimeType() to include audio/mp4 and audio/aac for
iOS WebKit compatibility.
