### PR TITLE
Update repository name in setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Optional Pro plugins, if they exist in the future, will live in a separate priva
 
 ```bash
 git clone <repo-url>
-cd whisperprompt
+cd scribably
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
Updated the CONTRIBUTING.md documentation to reflect the correct repository name in the setup instructions.

## Changes
- Updated the `cd` command in the setup instructions from `cd whisperprompt` to `cd scribably` to match the actual repository name

## Details
This change ensures that developers following the contribution guidelines will use the correct directory name when cloning and setting up the project locally.
