### PR TITLE
feat: display detected language and allow one-click correction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { useHistory } from './hooks/useHistory'
 import { initializeProviders } from './providers/init'
 import { isConfigured } from './services/config'
 import { markdownToLatex } from './services/markdown-to-latex'
+import { normalizeLanguage, SUPPORTED_LANGUAGES } from './services/languages'
+import { recordCorrection, getTopCorrection } from './services/language-feedback'
 import { AudioRecorder } from './components/AudioRecorder'
 import { TranscriptionResult } from './components/TranscriptionResult'
 import { ExportBar } from './components/ExportBar'
@@ -30,6 +32,8 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const lastSavedTxRef = useRef<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [showLatex, setShowLatex] = useState(false)
+  const [lastAudio, setLastAudio] = useState<Blob | null>(null)
+  const [txDetectedLanguage, setTxDetectedLanguage] = useState<string | null>(null)
 
   const processingEnabled = config.enableCleaning || config.enablePrompt
 
@@ -50,9 +54,18 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   useEffect(() => {
     if (audioBlob && config.sttProvider) {
       console.log('[WP:app] Audio blob ready, triggering transcription')
+      setLastAudio(audioBlob)
       transcribe(audioBlob, config.sttProvider.providerId, config.language)
     }
   }, [audioBlob])
+
+  useEffect(() => {
+    if (txState === 'done' && txResult) {
+      if (txResult.language) {
+        setTxDetectedLanguage(normalizeLanguage(txResult.language) ?? txResult.language)
+      }
+    }
+  }, [txState, txResult])
 
   useEffect(() => {
     if (txState === 'done' && txResult?.text) {
@@ -120,9 +133,16 @@ export default function App({ theme, onThemeToggle }: AppProps) {
     if (config.sttProvider) {
       selectEntry(null)
       console.log('[WP:app] File upload, triggering transcription | name:', file.name, '| size:', file.size)
+      setLastAudio(file)
       transcribe(file, config.sttProvider.providerId, config.language)
     }
   }, [config, transcribe, selectEntry])
+
+  const handleReTranscribe = useCallback((code: string) => {
+    if (!lastAudio || !config.sttProvider) return
+    recordCorrection(code)
+    transcribe(lastAudio, config.sttProvider.providerId, code)
+  }, [lastAudio, config, transcribe])
 
   const handleStartRecording = useCallback(() => {
     selectEntry(null)
@@ -148,6 +168,13 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const exportText = displayPromptText || displayCleanedText || displayRawText || ''
   const latexText = useMemo(() => exportText ? markdownToLatex(exportText) : null, [exportText])
   const hasResult = !!(displayRawText)
+
+  const suggestedDefault = useMemo(() => {
+    if (!txDetectedLanguage) return null
+    const top = getTopCorrection()
+    if (!top || top === config.language) return null
+    return top
+  }, [txDetectedLanguage, config.language])
 
   const settingsButton = (
     <button
@@ -245,6 +272,11 @@ export default function App({ theme, onThemeToggle }: AppProps) {
             onCleanedTextChange={!isViewingHistory ? setCleanedText : undefined}
             showLatex={showLatex}
             latexText={latexText}
+            detectedLanguage={!isViewingHistory ? txDetectedLanguage ?? undefined : undefined}
+            availableLanguages={[...SUPPORTED_LANGUAGES]}
+            onLanguageCorrection={!isViewingHistory ? handleReTranscribe : undefined}
+            suggestedDefault={!isViewingHistory ? suggestedDefault : undefined}
+            onAcceptDefault={!isViewingHistory ? (code) => updateConfig({ language: code }) : undefined}
           />
           <ExportBar
             text={exportText}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,8 +32,7 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const lastSavedTxRef = useRef<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(() => !isConfigured(config))
   const [showLatex, setShowLatex] = useState(false)
-  const [lastAudio, setLastAudio] = useState<Blob | null>(null)
-  const [txDetectedLanguage, setTxDetectedLanguage] = useState<string | null>(null)
+  const lastAudioRef = useRef<Blob | null>(null)
 
   const processingEnabled = config.enableCleaning || config.enablePrompt
 
@@ -50,18 +49,10 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   useEffect(() => {
     if (audioBlob && config.sttProvider) {
       console.log('[WP:app] Audio blob ready, triggering transcription')
-      setLastAudio(audioBlob)
+      lastAudioRef.current = audioBlob
       transcribe(audioBlob, config.sttProvider.providerId, config.language)
     }
   }, [audioBlob])
-
-  useEffect(() => {
-    if (txState === 'done' && txResult) {
-      if (txResult.language) {
-        setTxDetectedLanguage(normalizeLanguage(txResult.language) ?? txResult.language)
-      }
-    }
-  }, [txState, txResult])
 
   useEffect(() => {
     if (txState === 'done' && txResult?.text) {
@@ -129,16 +120,17 @@ export default function App({ theme, onThemeToggle }: AppProps) {
     if (config.sttProvider) {
       selectEntry(null)
       console.log('[WP:app] File upload, triggering transcription | name:', file.name, '| size:', file.size)
-      setLastAudio(file)
+      lastAudioRef.current = file
       transcribe(file, config.sttProvider.providerId, config.language)
     }
   }, [config, transcribe, selectEntry])
 
   const handleReTranscribe = useCallback((code: string) => {
-    if (!lastAudio || !config.sttProvider) return
+    const blob = lastAudioRef.current
+    if (!blob || !config.sttProvider) return
     recordCorrection(code)
-    transcribe(lastAudio, config.sttProvider.providerId, code)
-  }, [lastAudio, config, transcribe])
+    transcribe(blob, config.sttProvider.providerId, code)
+  }, [config, transcribe])
 
   const handleStartRecording = useCallback(() => {
     selectEntry(null)
@@ -164,6 +156,11 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const exportText = displayPromptText || displayCleanedText || displayRawText || ''
   const latexText = useMemo(() => exportText ? markdownToLatex(exportText) : null, [exportText])
   const hasResult = !!(displayRawText)
+
+  const txDetectedLanguage = useMemo(() => {
+    if (txState !== 'done' || !txResult?.language) return null
+    return normalizeLanguage(txResult.language) ?? txResult.language
+  }, [txState, txResult])
 
   const suggestedDefault = useMemo(() => {
     if (!txDetectedLanguage) return null

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -6,6 +6,7 @@ import { QRCodeTransfer } from './QRCodeTransfer'
 import { exportConfigToBase64, importConfigFromBase64 } from '../services/config'
 import { testSTTConnection, testLLMConnection } from '../services/connection-test'
 import type { AppConfig } from '../services/config-types'
+import { SUPPORTED_LANGUAGES } from '../services/languages'
 
 const STT_PROVIDERS = [
   { id: 'groq', name: 'Groq (Whisper Large v3)' },
@@ -15,13 +16,6 @@ const STT_PROVIDERS = [
 const LLM_PROVIDERS = [
   { id: 'openai-compatible', name: 'OpenAI-Compatible (OpenAI, Groq, OpenRouter, ...)' },
   { id: 'anthropic', name: 'Anthropic (Claude)' },
-]
-
-const LANGUAGES = [
-  { code: 'de', name: 'German' },
-  { code: 'en', name: 'English' },
-  { code: 'fr', name: 'Français' },
-  { code: 'es', name: 'Español' },
 ]
 
 interface SettingsPanelProps {
@@ -164,7 +158,7 @@ export function SettingsPanel({ isOpen, onClose, config, onConfigChange }: Setti
               onChange={e => onConfigChange({ language: e.target.value })}
               className="w-full appearance-none bg-bg-card rounded-[4px] px-3 py-2 text-sm text-text-primary border border-border-input focus:outline focus:outline-2 focus:outline-[rgb(20,110,245)] transition-colors"
             >
-              {LANGUAGES.map(l => (
+              {SUPPORTED_LANGUAGES.map(l => (
                 <option key={l.code} value={l.code}>{l.name}</option>
               ))}
             </select>

--- a/src/components/TranscriptionResult.test.tsx
+++ b/src/components/TranscriptionResult.test.tsx
@@ -2,6 +2,13 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TranscriptionResult } from './TranscriptionResult'
 
+const AVAILABLE_LANGUAGES = [
+  { code: 'de', name: 'German' },
+  { code: 'en', name: 'English' },
+  { code: 'fr', name: 'Français' },
+  { code: 'es', name: 'Español' },
+]
+
 describe('TranscriptionResult', () => {
   it('renders only raw tab by default', () => {
     render(<TranscriptionResult rawText="raw" cleanedText={null} promptText={null} isProcessing={false} />)
@@ -37,5 +44,43 @@ describe('TranscriptionResult', () => {
   it('shows placeholder when no text', () => {
     render(<TranscriptionResult rawText={null} cleanedText={null} promptText={null} isProcessing={false} />)
     expect(screen.getByText(/record something/i)).toBeInTheDocument()
+  })
+
+  it('renders language badge with name when detectedLanguage is set', () => {
+    render(
+      <TranscriptionResult
+        rawText="test"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        detectedLanguage="de"
+        availableLanguages={AVAILABLE_LANGUAGES}
+      />
+    )
+    expect(screen.getByText('German')).toBeInTheDocument()
+  })
+
+  it('does not render language badge when detectedLanguage is absent', () => {
+    render(<TranscriptionResult rawText="test" cleanedText={null} promptText={null} isProcessing={false} />)
+    expect(screen.queryByText('German')).not.toBeInTheDocument()
+    expect(screen.queryByText('Fix language')).not.toBeInTheDocument()
+  })
+
+  it('calls onLanguageCorrection with selected code', async () => {
+    const onCorrection = vi.fn()
+    render(
+      <TranscriptionResult
+        rawText="test"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        detectedLanguage="de"
+        availableLanguages={AVAILABLE_LANGUAGES}
+        onLanguageCorrection={onCorrection}
+      />
+    )
+    const select = screen.getByRole('combobox', { name: /correct detected language/i })
+    await userEvent.selectOptions(select, 'fr')
+    expect(onCorrection).toHaveBeenCalledWith('fr')
   })
 })

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import { getLanguageName } from '../services/languages'
 
 type Tab = 'raw' | 'clean' | 'prompt'
 
@@ -16,6 +17,11 @@ interface TranscriptionResultProps {
   onCleanedTextChange?: (text: string) => void;
   latexText?: string | null;
   showLatex?: boolean;
+  detectedLanguage?: string;
+  availableLanguages?: { code: string; name: string }[];
+  onLanguageCorrection?: (code: string) => void;
+  suggestedDefault?: string | null;
+  onAcceptDefault?: (code: string) => void;
 }
 
 const ALL_TABS: { id: Tab; label: string }[] = [
@@ -30,6 +36,8 @@ export function TranscriptionResult({
   isCleanProcessing = false, isPromptProcessing = false,
   onClean, onPrompt, onCleanedTextChange,
   latexText, showLatex = false,
+  detectedLanguage, availableLanguages, onLanguageCorrection,
+  suggestedDefault, onAcceptDefault,
 }: TranscriptionResultProps) {
   const [activeTab, setActiveTab] = useState<Tab>('raw')
 
@@ -54,10 +62,13 @@ export function TranscriptionResult({
   const showCleanButton = showCleanTab && !!onClean && canProcess
   const showPromptButton = showPromptTab && !!onPrompt && canProcess
 
+  const detectedLanguageName = detectedLanguage ? getLanguageName(detectedLanguage) ?? detectedLanguage : undefined
+  const suggestedDefaultName = suggestedDefault ? getLanguageName(suggestedDefault) ?? suggestedDefault : undefined
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       {/* Tab bar */}
-      <div className="flex items-center gap-1 mb-3">
+      <div className="flex items-center gap-1 mb-3 flex-wrap">
         {visibleTabs.map(tab => (
           <button
             key={tab.id}
@@ -73,7 +84,47 @@ export function TranscriptionResult({
             {tab.label}
           </button>
         ))}
+
+        {detectedLanguage && detectedLanguageName && (
+          <div className="ml-auto flex items-center gap-1.5">
+            <span className="px-2 py-0.5 rounded-full bg-lemon-200/40 text-lemon-800 dark:text-lemon-400 text-[10px] font-clay-ui">
+              {detectedLanguageName}
+            </span>
+            {availableLanguages && onLanguageCorrection && (
+              <select
+                defaultValue=""
+                onChange={e => {
+                  if (e.target.value) onLanguageCorrection(e.target.value)
+                  e.target.value = ''
+                }}
+                className="appearance-none bg-transparent text-[10px] text-text-tertiary hover:text-text-primary cursor-pointer font-clay-ui border-none outline-none"
+                title="Re-transcribe with different language"
+                aria-label="Correct detected language"
+              >
+                <option value="" disabled>Fix language</option>
+                {availableLanguages.map(l => (
+                  <option key={l.code} value={l.code}>{l.name}</option>
+                ))}
+              </select>
+            )}
+          </div>
+        )}
       </div>
+
+      {/* Suggested default hint */}
+      {suggestedDefault && suggestedDefaultName && onAcceptDefault && (
+        <div className="mb-2 flex items-center gap-2 px-3 py-1.5 rounded-[8px] bg-lemon-200/30 border border-lemon-400/30">
+          <span className="text-[11px] text-lemon-800 dark:text-lemon-400 font-clay-ui flex-1">
+            Set <strong>{suggestedDefaultName}</strong> as default language?
+          </span>
+          <button
+            onClick={() => onAcceptDefault(suggestedDefault)}
+            className="px-2 py-0.5 rounded-[6px] text-[10px] font-clay-ui bg-lemon-400/60 text-lemon-900 transition-all hover:-rotate-6 hover:-translate-y-0.5 hover:shadow-[-4px_4px_0_0_#000]"
+          >
+            Yes
+          </button>
+        </div>
+      )}
 
       {/* Content area */}
       <div className="relative bg-bg-card border border-border-oat rounded-[24px] shadow-clay flex-1 overflow-auto text-sm leading-relaxed">

--- a/src/services/language-feedback.test.ts
+++ b/src/services/language-feedback.test.ts
@@ -1,0 +1,56 @@
+import { recordCorrection, getTopCorrection, reset } from './language-feedback'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => { store[key] = value },
+  removeItem: (key: string) => { delete store[key] },
+  clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+}
+
+beforeAll(() => {
+  vi.stubGlobal('localStorage', localStorageMock)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('language-feedback', () => {
+  beforeEach(() => localStorageMock.clear())
+
+  it('recordCorrection increments counter', () => {
+    recordCorrection('de')
+    recordCorrection('de')
+    const data = JSON.parse(localStorageMock.getItem('scribably-language-feedback') ?? '{}')
+    expect(data['de']).toBe(2)
+  })
+
+  it('getTopCorrection returns null when below threshold', () => {
+    recordCorrection('de')
+    recordCorrection('de')
+    expect(getTopCorrection(3)).toBeNull()
+  })
+
+  it('getTopCorrection returns code when at threshold', () => {
+    recordCorrection('de')
+    recordCorrection('de')
+    recordCorrection('de')
+    expect(getTopCorrection(3)).toBe('de')
+  })
+
+  it('getTopCorrection returns top language when multiple', () => {
+    recordCorrection('de')
+    recordCorrection('de')
+    recordCorrection('de')
+    recordCorrection('fr')
+    recordCorrection('fr')
+    expect(getTopCorrection(3)).toBe('de')
+  })
+
+  it('reset removes the key', () => {
+    recordCorrection('de')
+    reset()
+    expect(localStorageMock.getItem('scribably-language-feedback')).toBeNull()
+  })
+})

--- a/src/services/language-feedback.ts
+++ b/src/services/language-feedback.ts
@@ -1,0 +1,22 @@
+const KEY = 'scribably-language-feedback'
+
+function load(): Record<string, number> {
+  try { return JSON.parse(localStorage.getItem(KEY) ?? '{}') } catch { return {} }
+}
+
+export function recordCorrection(code: string): void {
+  const data = load()
+  data[code] = (data[code] ?? 0) + 1
+  localStorage.setItem(KEY, JSON.stringify(data))
+}
+
+export function getTopCorrection(threshold = 3): string | null {
+  const data = load()
+  const [top] = Object.entries(data).sort(([, a], [, b]) => b - a)
+  if (!top || top[1] < threshold) return null
+  return top[0]
+}
+
+export function reset(): void {
+  localStorage.removeItem(KEY)
+}

--- a/src/services/languages.test.ts
+++ b/src/services/languages.test.ts
@@ -1,0 +1,6 @@
+import { normalizeLanguage, getLanguageName } from './languages'
+
+it('normalizes ISO code', () => expect(normalizeLanguage('de')).toBe('de'))
+it('normalizes English name', () => expect(normalizeLanguage('german')).toBe('de'))
+it('returns null for unknown', () => expect(normalizeLanguage('klingon')).toBeNull())
+it('gets name from code', () => expect(getLanguageName('en')).toBe('English'))

--- a/src/services/languages.ts
+++ b/src/services/languages.ts
@@ -1,0 +1,18 @@
+export const SUPPORTED_LANGUAGES = [
+  { code: 'de', name: 'German' },
+  { code: 'en', name: 'English' },
+  { code: 'fr', name: 'Français' },
+  { code: 'es', name: 'Español' },
+] as const
+
+export function normalizeLanguage(input: string): string | null {
+  const lower = input.toLowerCase()
+  const byCode = SUPPORTED_LANGUAGES.find(l => l.code === lower)
+  if (byCode) return byCode.code
+  const byName = SUPPORTED_LANGUAGES.find(l => l.name.toLowerCase() === lower)
+  return byName?.code ?? null
+}
+
+export function getLanguageName(code: string): string | undefined {
+  return SUPPORTED_LANGUAGES.find(l => l.code === code)?.name
+}


### PR DESCRIPTION
Closes #15

- Shared language list extracted to `src/services/languages.ts` with normalization (ISO ↔ full English name, e.g. `german` → `de`)
- Language feedback counter in separate `localStorage` key (`scribably-language-feedback`) — not part of QR export
- Detected language badge + correction select in `TranscriptionResult`
- One-click re-transcribe on same audio blob with corrected language
- Default language suggestion after ≥3 corrections to same language