### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/services/markdown-to-latex.ts
+++ b/src/services/markdown-to-latex.ts
@@ -36,7 +36,7 @@ function processInlineText(raw: string): string {
     } else if (full.startsWith('`')) {
       parts.push(`\\texttt{${escapeLatex(match[4])}}`)
     } else if (full.startsWith('[')) {
-      parts.push(`\\href{${match[6]}}{${escapeLatex(match[5])}}`)
+      parts.push(`\\href{${escapeLatex(match[6])}}{${escapeLatex(match[5])}}`)
     }
 
     lastIndex = match.index + full.length


### PR DESCRIPTION
Potential fix for [https://github.com/rico-twe/scribably/security/code-scanning/2](https://github.com/rico-twe/scribably/security/code-scanning/2)

General fix: ensure *all* user-controlled text embedded into LaTeX is escaped consistently, not only plain text segments. Avoid leaving any branch that interpolates raw input into LaTeX commands.

Best targeted fix here: in `src/services/markdown-to-latex.ts`, update the link branch in `processInlineText` so that `match[6]` (URL) is escaped before insertion into `\href{...}`. This preserves functionality (still emits `\href`) while removing the unescaped input path. No new imports or dependencies are needed.

Change region: the `else if (full.startsWith('['))` block around current line 39.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
