### PR TITLE
feat: microphone device selector with persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ interface AppProps {
 
 export default function App({ theme, onThemeToggle }: AppProps) {
   const { config, updateConfig } = useConfig()
-  const { state: recState, duration, audioBlob, error: recError, startRecording, stopRecording } = useAudioRecorder()
+  const { state: recState, duration, audioBlob, error: recError, warning: recWarning, startRecording, stopRecording } = useAudioRecorder(config.audioDeviceId ?? undefined)
   const { state: txState, result: txResult, error: txError, transcribe } = useTranscription()
   const { state: tpState, cleanState, promptState, cleanedText, setCleanedText, promptText, error: tpError, process } = useTextProcessing()
   const { entries: historyEntries, addEntry, updateLatest, selectedEntry, selectEntry, clearHistory } = useHistory()
@@ -194,6 +194,15 @@ export default function App({ theme, onThemeToggle }: AppProps) {
                 <span className="px-2 py-0.5 rounded-full bg-matcha-300/40 text-matcha-800 dark:text-matcha-300 text-[10px] font-clay-ui">STT</span>
               </div>
               <p className="text-xs text-text-secondary leading-relaxed whitespace-pre-wrap">{displayRawText}</p>
+            </div>
+          )}
+
+          {recWarning && (
+            <div className="animate-fade-in flex items-start gap-2 px-3 py-2 rounded-[8px] bg-lemon-400/10 border border-lemon-400/30">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-lemon-600 mt-0.5 flex-shrink-0">
+                <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /><line x1="12" x2="12" y1="9" y2="13" /><line x1="12" x2="12.01" y1="17" y2="17" />
+              </svg>
+              <p className="text-lemon-700 dark:text-lemon-400 text-xs leading-relaxed">{recWarning}</p>
             </div>
           )}
 

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,7 +1,21 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { SettingsPanel } from './SettingsPanel'
 import { DEFAULT_CONFIG } from '../services/config-types'
+
+vi.mock('../services/audio', () => ({
+  listAudioInputDevices: vi.fn().mockResolvedValue([
+    { deviceId: 'mic-1', label: 'Built-in Mic' },
+    { deviceId: 'mic-2', label: 'USB Mic' },
+  ]),
+  testSTTConnection: vi.fn(),
+  testLLMConnection: vi.fn(),
+}))
+
+vi.mock('../services/connection-test', () => ({
+  testSTTConnection: vi.fn(),
+  testLLMConnection: vi.fn(),
+}))
 
 describe('SettingsPanel', () => {
   const defaultProps = {
@@ -58,5 +72,22 @@ describe('SettingsPanel', () => {
     render(<SettingsPanel {...defaultProps} onConfigChange={onConfigChange} />)
     await userEvent.type(screen.getByPlaceholderText(/custom instructions/i), 'Test')
     expect(onConfigChange).toHaveBeenCalled()
+  })
+
+  it('renders microphone select with audioinput devices', async () => {
+    render(<SettingsPanel {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Built-in Mic')).toBeInTheDocument()
+      expect(screen.getByText('USB Mic')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onConfigChange with audioDeviceId when mic selected', async () => {
+    const onConfigChange = vi.fn()
+    render(<SettingsPanel {...defaultProps} onConfigChange={onConfigChange} />)
+    await waitFor(() => screen.getByText('Built-in Mic'))
+    const select = screen.getByDisplayValue('Default')
+    await userEvent.selectOptions(select, 'mic-2')
+    expect(onConfigChange).toHaveBeenCalledWith({ audioDeviceId: 'mic-2' })
   })
 })

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { getSystemPrompt } from '../providers/text-processing/prompts'
 import { ProviderConfig } from './ProviderConfig'
@@ -5,6 +6,7 @@ import { ConnectionTestButton } from './ConnectionTestButton'
 import { QRCodeTransfer } from './QRCodeTransfer'
 import { exportConfigToBase64, importConfigFromBase64 } from '../services/config'
 import { testSTTConnection, testLLMConnection } from '../services/connection-test'
+import { listAudioInputDevices } from '../services/audio'
 import type { AppConfig } from '../services/config-types'
 
 const STT_PROVIDERS = [
@@ -38,6 +40,12 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 }
 
 export function SettingsPanel({ isOpen, onClose, config, onConfigChange }: SettingsPanelProps) {
+  const [audioDevices, setAudioDevices] = useState<{ deviceId: string; label: string }[]>([])
+
+  useEffect(() => {
+    listAudioInputDevices().then(setAudioDevices).catch(() => {})
+  }, [])
+
   const handleImport = (encoded: string) => {
     try {
       const imported = importConfigFromBase64(encoded)
@@ -169,6 +177,31 @@ export function SettingsPanel({ isOpen, onClose, config, onConfigChange }: Setti
               ))}
             </select>
           </section>
+
+          {/* Divider */}
+          <div className="border-t border-border-oat" />
+
+          {/* Microphone */}
+          <section>
+            <SectionLabel>Microphone</SectionLabel>
+            {audioDevices.length === 0 ? (
+              <p className="text-xs text-text-tertiary">Grant microphone permission to see device names.</p>
+            ) : (
+              <select
+                value={config.audioDeviceId ?? ''}
+                onChange={e => onConfigChange({ audioDeviceId: e.target.value || undefined })}
+                className="w-full appearance-none bg-bg-card rounded-[4px] px-3 py-2 text-sm text-text-primary border border-border-input focus:outline focus:outline-2 focus:outline-[rgb(20,110,245)] transition-colors"
+              >
+                <option value="">Default</option>
+                {audioDevices.map(d => (
+                  <option key={d.deviceId} value={d.deviceId}>{d.label}</option>
+                ))}
+              </select>
+            )}
+          </section>
+
+          {/* Divider */}
+          <div className="border-t border-border-oat" />
 
           {/* Custom prompt */}
           <section>

--- a/src/hooks/useAudioRecorder.test.ts
+++ b/src/hooks/useAudioRecorder.test.ts
@@ -9,8 +9,8 @@ const mockCreateAudioRecorder = vi.fn()
 const mockGetDuration = vi.fn().mockReturnValue(0)
 
 vi.mock('../services/audio', () => ({
-  createAudioRecorder: (...args: any[]) => {
-    mockCreateAudioRecorder(...args)
+  createAudioRecorder: (opts?: { deviceId?: string }) => {
+    mockCreateAudioRecorder(opts)
     return {
       start: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn().mockResolvedValue(new Blob(['audio'])),

--- a/src/hooks/useAudioRecorder.test.ts
+++ b/src/hooks/useAudioRecorder.test.ts
@@ -1,29 +1,37 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, act } from '@testing-library/react'
 import { useAudioRecorder } from './useAudioRecorder'
 
-// Mock the audio service
-vi.mock('../services/audio', () => {
-  const listeners = new Set<(s: string) => void>()
-  return {
-    createAudioRecorder: () => ({
-      start: vi.fn().mockImplementation(async () => {
-        listeners.forEach(cb => cb('recording'))
-      }),
-      stop: vi.fn().mockImplementation(async () => {
-        listeners.forEach(cb => cb('idle'))
-        return new Blob(['audio'])
-      }),
-      getState: vi.fn().mockReturnValue('idle'),
-      getDuration: vi.fn().mockReturnValue(0),
-      onStateChange: vi.fn().mockImplementation((cb: (s: string) => void) => {
-        listeners.add(cb)
-        return () => listeners.delete(cb)
-      }),
-    }),
-  }
+const mockStart = vi.fn()
+const mockStop = vi.fn().mockResolvedValue(new Blob(['audio']))
+const mockGetDuration = vi.fn().mockReturnValue(0)
+const mockOnStateChange = vi.fn().mockImplementation((_cb: (s: string) => void) => {
+  return () => {}
 })
+const mockCreateAudioRecorder = vi.fn()
+
+let mockUsedFallback = false
+
+vi.mock('../services/audio', () => ({
+  createAudioRecorder: (...args: any[]) => {
+    mockCreateAudioRecorder(...args)
+    return {
+      start: mockStart.mockImplementation(async () => {}),
+      stop: mockStop,
+      getState: vi.fn().mockReturnValue('idle'),
+      getDuration: mockGetDuration,
+      onStateChange: mockOnStateChange,
+      get usedFallback() { return mockUsedFallback },
+    }
+  },
+}))
 
 describe('useAudioRecorder', () => {
+  beforeEach(() => {
+    mockUsedFallback = false
+    vi.clearAllMocks()
+    mockStop.mockResolvedValue(new Blob(['audio']))
+  })
+
   it('starts in idle state', () => {
     const { result } = renderHook(() => useAudioRecorder())
     expect(result.current.state).toBe('idle')
@@ -33,5 +41,32 @@ describe('useAudioRecorder', () => {
     const { result } = renderHook(() => useAudioRecorder())
     expect(typeof result.current.startRecording).toBe('function')
     expect(typeof result.current.stopRecording).toBe('function')
+  })
+
+  it('passes deviceId to createAudioRecorder', async () => {
+    const { result } = renderHook(() => useAudioRecorder('mic-1'))
+    await act(() => result.current.startRecording())
+    expect(mockCreateAudioRecorder).toHaveBeenCalledWith({ deviceId: 'mic-1' })
+  })
+
+  it('passes undefined deviceId when no arg given', async () => {
+    const { result } = renderHook(() => useAudioRecorder())
+    await act(() => result.current.startRecording())
+    expect(mockCreateAudioRecorder).toHaveBeenCalledWith({ deviceId: undefined })
+  })
+
+  it('sets warning when recorder used fallback', async () => {
+    mockUsedFallback = true
+    const { result } = renderHook(() => useAudioRecorder('missing-mic'))
+    await act(() => result.current.startRecording())
+    expect(result.current.warning).toBeTruthy()
+    expect(result.current.warning).toMatch(/not available/i)
+  })
+
+  it('warning is null when no fallback used', async () => {
+    mockUsedFallback = false
+    const { result } = renderHook(() => useAudioRecorder('mic-1'))
+    await act(() => result.current.startRecording())
+    expect(result.current.warning).toBeNull()
   })
 })

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,22 +1,27 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { createAudioRecorder, type RecordingState, type AudioRecorderService } from '../services/audio'
 
-export function useAudioRecorder() {
+export function useAudioRecorder(deviceId?: string) {
   const [state, setState] = useState<RecordingState>('idle')
   const [duration, setDuration] = useState(0)
   const [audioBlob, setAudioBlob] = useState<Blob | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [warning, setWarning] = useState<string | null>(null)
   const recorderRef = useRef<AudioRecorderService | null>(null)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const startRecording = useCallback(async () => {
     try {
       setError(null)
+      setWarning(null)
       setAudioBlob(null)
-      const recorder = createAudioRecorder()
+      const recorder = createAudioRecorder({ deviceId })
       recorderRef.current = recorder
       recorder.onStateChange(setState)
       await recorder.start()
+      if (recorder.usedFallback) {
+        setWarning('Selected microphone not available. Using default.')
+      }
       intervalRef.current = setInterval(() => {
         setDuration(recorder.getDuration())
       }, 100)
@@ -24,7 +29,7 @@ export function useAudioRecorder() {
       setError(err instanceof Error ? err.message : 'Recording failed')
       setState('error')
     }
-  }, [])
+  }, [deviceId])
 
   const stopRecording = useCallback(async () => {
     if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null }
@@ -44,5 +49,5 @@ export function useAudioRecorder() {
     }
   }, [])
 
-  return { state, duration, audioBlob, error, startRecording, stopRecording }
+  return { state, duration, audioBlob, error, warning, startRecording, stopRecording }
 }

--- a/src/services/audio.test.ts
+++ b/src/services/audio.test.ts
@@ -1,4 +1,4 @@
-import { createAudioRecorder } from './audio'
+import { createAudioRecorder, listAudioInputDevices } from './audio'
 
 class MockMediaRecorder {
   state = 'inactive' as 'inactive' | 'recording'
@@ -20,13 +20,21 @@ class MockMediaRecorder {
   static isTypeSupported(type: string) { return type === 'audio/webm' }
 }
 
+const mockGetUserMedia = vi.fn().mockResolvedValue({
+  getTracks: () => [{ stop: vi.fn() }],
+})
+
 beforeAll(() => {
   (globalThis as any).MediaRecorder = MockMediaRecorder
   Object.defineProperty(globalThis.navigator, 'mediaDevices', {
     value: {
-      getUserMedia: vi.fn().mockResolvedValue({
-        getTracks: () => [{ stop: vi.fn() }],
-      }),
+      getUserMedia: mockGetUserMedia,
+      enumerateDevices: vi.fn().mockResolvedValue([
+        { kind: 'audioinput', deviceId: 'mic-1', label: 'Built-in Mic' },
+        { kind: 'audioinput', deviceId: 'mic-2', label: 'USB Mic' },
+        { kind: 'videoinput', deviceId: 'cam-1', label: 'Webcam' },
+        { kind: 'audiooutput', deviceId: 'spk-1', label: 'Speaker' },
+      ]),
     },
     writable: true,
   })
@@ -70,5 +78,40 @@ describe('AudioRecorderService', () => {
   it('rejects stop when not recording', async () => {
     const recorder = createAudioRecorder()
     await expect(recorder.stop()).rejects.toThrow('No active recording')
+  })
+})
+
+describe('deviceId support', () => {
+  beforeEach(() => { mockGetUserMedia.mockClear() })
+
+  it('passes exact deviceId constraint to getUserMedia', async () => {
+    const recorder = createAudioRecorder({ deviceId: 'mic-1' })
+    await recorder.start()
+    expect(mockGetUserMedia).toHaveBeenCalledWith({
+      audio: { deviceId: { exact: 'mic-1' } },
+    })
+    await recorder.stop()
+  })
+
+  it('falls back to default mic on OverconstrainedError', async () => {
+    const err = Object.assign(new Error('Overconstrained'), { name: 'OverconstrainedError' })
+    mockGetUserMedia
+      .mockRejectedValueOnce(err)
+      .mockResolvedValueOnce({ getTracks: () => [{ stop: vi.fn() }] })
+    const recorder = createAudioRecorder({ deviceId: 'missing-mic' })
+    await recorder.start()
+    expect(recorder.usedFallback).toBe(true)
+    expect(mockGetUserMedia).toHaveBeenCalledTimes(2)
+    expect(mockGetUserMedia).toHaveBeenLastCalledWith({ audio: true })
+    await recorder.stop()
+  })
+})
+
+describe('listAudioInputDevices', () => {
+  it('returns only audioinput devices', async () => {
+    const devices = await listAudioInputDevices()
+    expect(devices).toHaveLength(2)
+    expect(devices.every(d => d.deviceId && d.label)).toBe(true)
+    expect(devices.map(d => d.deviceId)).toEqual(['mic-1', 'mic-2'])
   })
 })

--- a/src/services/audio.ts
+++ b/src/services/audio.ts
@@ -6,6 +6,7 @@ export interface AudioRecorderService {
   getState(): RecordingState;
   getDuration(): number;
   onStateChange(callback: (state: RecordingState) => void): () => void;
+  usedFallback: boolean;
 }
 
 const MAX_DURATION_MS = 5 * 60 * 1000
@@ -21,9 +22,12 @@ function getSupportedMimeType(): string {
   throw new Error('No supported audio format found in this browser.')
 }
 
-function getMediaStream(): Promise<MediaStream> {
+function getMediaStream(deviceId?: string): Promise<MediaStream> {
+  const constraints: MediaStreamConstraints = {
+    audio: deviceId ? { deviceId: { exact: deviceId } } : true,
+  }
   if (navigator.mediaDevices?.getUserMedia) {
-    return navigator.mediaDevices.getUserMedia({ audio: true })
+    return navigator.mediaDevices.getUserMedia(constraints)
   }
   const legacyGetUserMedia =
     (navigator as any).getUserMedia ||
@@ -31,13 +35,20 @@ function getMediaStream(): Promise<MediaStream> {
     (navigator as any).mozGetUserMedia
   if (legacyGetUserMedia) {
     return new Promise((resolve, reject) => {
-      legacyGetUserMedia.call(navigator, { audio: true }, resolve, reject)
+      legacyGetUserMedia.call(navigator, constraints, resolve, reject)
     })
   }
   throw new Error('Microphone access is not available in this browser.')
 }
 
-export function createAudioRecorder(): AudioRecorderService {
+export async function listAudioInputDevices(): Promise<{ deviceId: string; label: string }[]> {
+  const devices = await navigator.mediaDevices.enumerateDevices()
+  return devices
+    .filter(d => d.kind === 'audioinput')
+    .map(d => ({ deviceId: d.deviceId, label: d.label || d.deviceId }))
+}
+
+export function createAudioRecorder(opts?: { deviceId?: string }): AudioRecorderService {
   let state: RecordingState = 'idle'
   let mediaRecorder: MediaRecorder | null = null
   let chunks: Blob[] = []
@@ -51,9 +62,27 @@ export function createAudioRecorder(): AudioRecorderService {
   }
 
   const service: AudioRecorderService = {
+    usedFallback: false,
+
     async start() {
       const mimeType = getSupportedMimeType()
-      const stream = await getMediaStream()
+      let stream: MediaStream
+      const deviceId = opts?.deviceId
+      if (deviceId) {
+        try {
+          stream = await getMediaStream(deviceId)
+        } catch (err) {
+          const name = err instanceof Error ? err.name : ''
+          if (name === 'OverconstrainedError' || name === 'NotFoundError') {
+            service.usedFallback = true
+            stream = await getMediaStream()
+          } else {
+            throw err
+          }
+        }
+      } else {
+        stream = await getMediaStream()
+      }
       chunks = []
       mediaRecorder = new MediaRecorder(stream, { mimeType })
       mediaRecorder.ondataavailable = (e) => {

--- a/src/services/config-types.ts
+++ b/src/services/config-types.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
   customPrompt?: string;
   enableCleaning?: boolean;
   enablePrompt?: boolean;
+  audioDeviceId?: string;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {


### PR DESCRIPTION
Closes #13

Adds input device selection via `navigator.mediaDevices.enumerateDevices()` with localStorage persistence through `AppConfig.audioDeviceId`.

**Changes:**
- `AppConfig.audioDeviceId?: string` in config-types
- `createAudioRecorder({ deviceId? })` with `OverconstrainedError` fallback → `usedFallback` flag
- `listAudioInputDevices()` helper function
- `useAudioRecorder(deviceId?)` with `warning` state for fallback notification
- Settings panel: Microphone section (select rendered after permission granted)
- App: warning banner (Lemon) when fallback mic was used

**Verification:**
1. Settings → Microphone select shows available devices after permission
2. Selected device persists across reload (QR export includes it)
3. Remove selected device → fallback banner appears, recording still works