### PR TITLE
feat: SRT/VTT/DOCX export + segment timestamps + audio player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "docx": "^9.6.1",
         "html5-qrcode": "^2.3.8",
         "marked": "^18.0.0",
         "qrcode.react": "^4.2.0",
@@ -2235,6 +2236,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2343,6 +2350,56 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
+      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/docx/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -2778,6 +2835,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2824,6 +2891,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2861,6 +2934,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2889,6 +2968,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -3026,6 +3111,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3048,6 +3145,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -3394,6 +3500,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3507,6 +3619,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -3650,6 +3768,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3697,6 +3821,21 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -3773,6 +3912,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -3801,6 +3955,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3855,6 +4015,15 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4143,6 +4312,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
@@ -4400,6 +4575,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "docx": "^9.6.1",
     "html5-qrcode": "^2.3.8",
     "marked": "^18.0.0",
     "qrcode.react": "^4.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { initializeProviders } from './providers/init'
 import { isConfigured } from './services/config'
 import { markdownToLatex } from './services/markdown-to-latex'
 import { AudioRecorder } from './components/AudioRecorder'
+import { AudioPlayer } from './components/AudioPlayer'
 import { TranscriptionResult } from './components/TranscriptionResult'
 import { ExportBar } from './components/ExportBar'
 import { HistoryList } from './components/HistoryList'
@@ -30,6 +31,23 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const lastSavedTxRef = useRef<string | null>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [showLatex, setShowLatex] = useState(false)
+  const [uploadedFile, setUploadedFile] = useState<Blob | null>(null)
+  const [currentTime, setCurrentTime] = useState(0)
+  const audioRef = useRef<HTMLAudioElement>(null)
+
+  const activePlayerBlob = audioBlob ?? uploadedFile
+  const audioUrl = useMemo(
+    () => (activePlayerBlob ? URL.createObjectURL(activePlayerBlob) : null),
+    [activePlayerBlob],
+  )
+  useEffect(() => () => { if (audioUrl) URL.revokeObjectURL(audioUrl) }, [audioUrl])
+
+  const seekTo = useCallback((t: number) => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = t
+      audioRef.current.play()
+    }
+  }, [])
 
   const processingEnabled = config.enableCleaning || config.enablePrompt
 
@@ -119,6 +137,7 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const handleFileUpload = useCallback((file: File) => {
     if (config.sttProvider) {
       selectEntry(null)
+      setUploadedFile(file)
       console.log('[WP:app] File upload, triggering transcription | name:', file.name, '| size:', file.size)
       transcribe(file, config.sttProvider.providerId, config.language)
     }
@@ -148,6 +167,7 @@ export default function App({ theme, onThemeToggle }: AppProps) {
   const exportText = displayPromptText || displayCleanedText || displayRawText || ''
   const latexText = useMemo(() => exportText ? markdownToLatex(exportText) : null, [exportText])
   const hasResult = !!(displayRawText)
+  const segments = isViewingHistory ? undefined : txResult?.segments
 
   const settingsButton = (
     <button
@@ -231,6 +251,13 @@ export default function App({ theme, onThemeToggle }: AppProps) {
               </span>
             )}
           </div>
+          {audioUrl && hasResult && !isViewingHistory && (
+            <AudioPlayer
+              src={audioUrl}
+              audioRef={audioRef}
+              onTimeUpdate={setCurrentTime}
+            />
+          )}
           <TranscriptionResult
             rawText={displayRawText}
             cleanedText={displayCleanedText}
@@ -245,6 +272,9 @@ export default function App({ theme, onThemeToggle }: AppProps) {
             onCleanedTextChange={!isViewingHistory ? setCleanedText : undefined}
             showLatex={showLatex}
             latexText={latexText}
+            segments={segments}
+            currentTime={currentTime}
+            onSeek={seekTo}
           />
           <ExportBar
             text={exportText}
@@ -252,6 +282,7 @@ export default function App({ theme, onThemeToggle }: AppProps) {
             disabled={!displayRawText}
             showLatex={showLatex}
             onToggleLatex={() => setShowLatex(prev => !prev)}
+            segments={segments}
           />
         </div>
 

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -1,0 +1,21 @@
+import type { RefObject } from 'react'
+
+interface AudioPlayerProps {
+  src: string;
+  audioRef: RefObject<HTMLAudioElement | null>;
+  onTimeUpdate: (t: number) => void;
+}
+
+export function AudioPlayer({ src, audioRef, onTimeUpdate }: AudioPlayerProps) {
+  return (
+    <div className="mb-3 px-1">
+      <audio
+        ref={audioRef}
+        src={src}
+        controls
+        onTimeUpdate={(e) => onTimeUpdate(e.currentTarget.currentTime)}
+        className="w-full h-8 rounded-[8px]"
+      />
+    </div>
+  )
+}

--- a/src/components/ExportBar.test.tsx
+++ b/src/components/ExportBar.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { ExportBar } from './ExportBar'
+import { EXAMPLE_SEGMENTS } from '../export/__fixtures__/example-transcript'
 
 const defaultProps = {
   text: 'test',
@@ -19,6 +20,13 @@ describe('ExportBar', () => {
     expect(screen.getByText(/latex/i)).toBeInTheDocument()
   })
 
+  it('renders .srt, .vtt and .docx buttons', () => {
+    render(<ExportBar {...defaultProps} />)
+    expect(screen.getByText(/\.srt/i)).toBeInTheDocument()
+    expect(screen.getByText(/\.vtt/i)).toBeInTheDocument()
+    expect(screen.getByText(/\.docx/i)).toBeInTheDocument()
+  })
+
   it('copy button calls clipboard API', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, { clipboard: { writeText } })
@@ -33,6 +41,23 @@ describe('ExportBar', () => {
     expect(screen.getByText(/\.tex/i)).toBeInTheDocument()
     expect(screen.queryByText(/\.md/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/\.txt/i)).not.toBeInTheDocument()
+  })
+
+  it('.srt and .vtt are disabled without segments', () => {
+    render(<ExportBar {...defaultProps} />)
+    expect(screen.getByText(/\.srt/i).closest('button')).toBeDisabled()
+    expect(screen.getByText(/\.vtt/i).closest('button')).toBeDisabled()
+  })
+
+  it('.srt and .vtt are enabled with segments', () => {
+    render(<ExportBar {...defaultProps} segments={EXAMPLE_SEGMENTS} />)
+    expect(screen.getByText(/\.srt/i).closest('button')).not.toBeDisabled()
+    expect(screen.getByText(/\.vtt/i).closest('button')).not.toBeDisabled()
+  })
+
+  it('.docx is always enabled', () => {
+    render(<ExportBar {...defaultProps} />)
+    expect(screen.getByText(/\.docx/i).closest('button')).not.toBeDisabled()
   })
 
   it('buttons are disabled when disabled prop is true', () => {

--- a/src/components/ExportBar.tsx
+++ b/src/components/ExportBar.tsx
@@ -1,4 +1,8 @@
 import { useState } from 'react'
+import type { Segment } from '../providers/transcription/types'
+import { segmentsToSrt } from '../export/srt'
+import { segmentsToVtt } from '../export/vtt'
+import { textToDocx } from '../export/docx'
 
 interface ExportBarProps {
   text: string;
@@ -6,10 +10,11 @@ interface ExportBarProps {
   disabled: boolean;
   showLatex: boolean;
   onToggleLatex: () => void;
+  segments?: Segment[];
 }
 
-function downloadFile(content: string, filename: string, mimeType: string) {
-  const blob = new Blob([content], { type: mimeType })
+function downloadFile(content: string | Blob, filename: string, mimeType: string) {
+  const blob = content instanceof Blob ? content : new Blob([content], { type: mimeType })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
@@ -18,7 +23,15 @@ function downloadFile(content: string, filename: string, mimeType: string) {
   URL.revokeObjectURL(url)
 }
 
-export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex }: ExportBarProps) {
+const downloadIcon = (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" x2="12" y1="15" y2="3" />
+  </svg>
+)
+
+export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex, segments }: ExportBarProps) {
   const [copied, setCopied] = useState(false)
 
   const activeText = showLatex && latexText ? latexText : text
@@ -29,6 +42,11 @@ export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex 
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const handleDocxDownload = async () => {
+    const blob = await textToDocx(text, segments)
+    downloadFile(blob, 'transcript.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document')
+  }
+
   const btnClass = `
     flex items-center gap-1.5 px-3 py-1.5 rounded-[12px] text-xs font-clay-ui transition-all
     bg-bg-card text-text-secondary border border-border-oat shadow-clay
@@ -37,7 +55,7 @@ export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex 
   `
 
   return (
-    <div className="flex gap-1.5 mt-3">
+    <div className="flex flex-wrap gap-1.5 mt-3">
       <button onClick={handleCopy} disabled={disabled} data-umami-event="export-copy" className={`${btnClass} hover:bg-slushie-500/10`}>
         {copied ? (
           <>
@@ -81,11 +99,7 @@ export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex 
           data-umami-event="export-tex"
           className={`${btnClass} hover:bg-ube-300/10`}
         >
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-            <polyline points="7 10 12 15 17 10" />
-            <line x1="12" x2="12" y1="15" y2="3" />
-          </svg>
+          {downloadIcon}
           .tex
         </button>
       ) : (
@@ -96,11 +110,7 @@ export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex 
             data-umami-event="export-md"
             className={`${btnClass} hover:bg-matcha-300/10`}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <polyline points="7 10 12 15 17 10" />
-              <line x1="12" x2="12" y1="15" y2="3" />
-            </svg>
+            {downloadIcon}
             .md
           </button>
           <button
@@ -109,15 +119,41 @@ export function ExportBar({ text, latexText, disabled, showLatex, onToggleLatex 
             data-umami-event="export-txt"
             className={`${btnClass} hover:bg-lemon-400/10`}
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-              <polyline points="7 10 12 15 17 10" />
-              <line x1="12" x2="12" y1="15" y2="3" />
-            </svg>
+            {downloadIcon}
             .txt
           </button>
         </>
       )}
+
+      <button
+        onClick={() => downloadFile(segmentsToSrt(segments!), 'transcript.srt', 'text/srt')}
+        disabled={disabled || !segments}
+        data-umami-event="export-srt"
+        className={`${btnClass} hover:bg-matcha-400/10`}
+      >
+        {downloadIcon}
+        .srt
+      </button>
+
+      <button
+        onClick={() => downloadFile(segmentsToVtt(segments!), 'transcript.vtt', 'text/vtt')}
+        disabled={disabled || !segments}
+        data-umami-event="export-vtt"
+        className={`${btnClass} hover:bg-slushie-400/10`}
+      >
+        {downloadIcon}
+        .vtt
+      </button>
+
+      <button
+        onClick={handleDocxDownload}
+        disabled={disabled}
+        data-umami-event="export-docx"
+        className={`${btnClass} hover:bg-ube-400/10`}
+      >
+        {downloadIcon}
+        .docx
+      </button>
     </div>
   )
 }

--- a/src/components/TranscriptionResult.test.tsx
+++ b/src/components/TranscriptionResult.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TranscriptionResult } from './TranscriptionResult'
+import { EXAMPLE_SEGMENTS } from '../export/__fixtures__/example-transcript'
 
 describe('TranscriptionResult', () => {
   it('renders only raw tab by default', () => {
@@ -37,5 +38,63 @@ describe('TranscriptionResult', () => {
   it('shows placeholder when no text', () => {
     render(<TranscriptionResult rawText={null} cleanedText={null} promptText={null} isProcessing={false} />)
     expect(screen.getByText(/record something/i)).toBeInTheDocument()
+  })
+
+  it('renders segments as clickable spans when segments prop is provided', () => {
+    render(
+      <TranscriptionResult
+        rawText="full text"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        segments={EXAMPLE_SEGMENTS}
+      />
+    )
+    expect(screen.getByText('Hallo und willkommen.')).toBeInTheDocument()
+    expect(screen.getByText('Das ist ein Testsatz.')).toBeInTheDocument()
+  })
+
+  it('calls onSeek with segment start time on click', async () => {
+    const onSeek = vi.fn()
+    render(
+      <TranscriptionResult
+        rawText="full text"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        segments={EXAMPLE_SEGMENTS}
+        onSeek={onSeek}
+      />
+    )
+    await userEvent.click(screen.getByText('Das ist ein Testsatz.'))
+    expect(onSeek).toHaveBeenCalledWith(2.5)
+  })
+
+  it('highlights active segment based on currentTime', () => {
+    const { rerender } = render(
+      <TranscriptionResult
+        rawText="full text"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        segments={EXAMPLE_SEGMENTS}
+        currentTime={3}
+      />
+    )
+    const activeSpan = screen.getByText('Das ist ein Testsatz.')
+    expect(activeSpan.className).toContain('bg-lemon-300/30')
+
+    rerender(
+      <TranscriptionResult
+        rawText="full text"
+        cleanedText={null}
+        promptText={null}
+        isProcessing={false}
+        segments={EXAMPLE_SEGMENTS}
+        currentTime={0.5}
+      />
+    )
+    expect(screen.getByText('Hallo und willkommen.').className).toContain('bg-lemon-300/30')
+    expect(screen.getByText('Das ist ein Testsatz.').className).not.toContain('bg-lemon-300/30')
   })
 })

--- a/src/components/TranscriptionResult.tsx
+++ b/src/components/TranscriptionResult.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react'
+import type { Segment } from '../providers/transcription/types'
 
 type Tab = 'raw' | 'clean' | 'prompt'
 
@@ -16,6 +17,9 @@ interface TranscriptionResultProps {
   onCleanedTextChange?: (text: string) => void;
   latexText?: string | null;
   showLatex?: boolean;
+  segments?: Segment[];
+  currentTime?: number;
+  onSeek?: (t: number) => void;
 }
 
 const ALL_TABS: { id: Tab; label: string }[] = [
@@ -30,6 +34,7 @@ export function TranscriptionResult({
   isCleanProcessing = false, isPromptProcessing = false,
   onClean, onPrompt, onCleanedTextChange,
   latexText, showLatex = false,
+  segments, currentTime, onSeek,
 }: TranscriptionResultProps) {
   const [activeTab, setActiveTab] = useState<Tab>('raw')
 
@@ -90,6 +95,21 @@ export function TranscriptionResult({
             onChange={e => onCleanedTextChange(e.target.value)}
             className="w-full h-full bg-transparent p-5 text-text-secondary resize-none outline-none whitespace-pre-wrap text-[13px] leading-[1.7]"
           />
+        ) : effectiveTab === 'raw' && segments && segments.length > 0 ? (
+          <p className="p-5 whitespace-pre-wrap text-text-secondary text-[13px] leading-[1.7]">
+            {segments.map((seg, i) => {
+              const active = currentTime != null && currentTime >= seg.start && currentTime < seg.end
+              return (
+                <span
+                  key={i}
+                  onClick={() => onSeek?.(seg.start)}
+                  className={`cursor-pointer rounded px-0.5 transition-colors hover:underline ${active ? 'bg-lemon-300/30' : ''}`}
+                >
+                  {seg.text}
+                </span>
+              )
+            })}
+          </p>
         ) : currentText ? (
           <p className="p-5 whitespace-pre-wrap text-text-secondary text-[13px] leading-[1.7]">{currentText}</p>
         ) : (

--- a/src/export/__fixtures__/example-transcript.ts
+++ b/src/export/__fixtures__/example-transcript.ts
@@ -1,0 +1,7 @@
+import type { Segment } from '../../providers/transcription/types'
+
+export const EXAMPLE_SEGMENTS: Segment[] = [
+  { start: 0, end: 2.5, text: 'Hallo und willkommen.' },
+  { start: 2.5, end: 5.8, text: 'Das ist ein Testsatz.' },
+  { start: 5.8, end: 9.42, text: 'Noch ein dritter.' },
+]

--- a/src/export/docx.test.ts
+++ b/src/export/docx.test.ts
@@ -1,0 +1,18 @@
+import { textToDocx } from './docx'
+import { EXAMPLE_SEGMENTS } from './__fixtures__/example-transcript'
+
+const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+describe('textToDocx', () => {
+  it('produces a docx blob with correct MIME type', async () => {
+    const blob = await textToDocx('Hallo Welt.', EXAMPLE_SEGMENTS)
+    expect(blob.type).toBe(DOCX_MIME)
+    expect(blob.size).toBeGreaterThan(1000)
+  })
+
+  it('works without segments using flat text', async () => {
+    const blob = await textToDocx('Absatz eins.\n\nAbsatz zwei.')
+    expect(blob.type).toBe(DOCX_MIME)
+    expect(blob.size).toBeGreaterThan(1000)
+  })
+})

--- a/src/export/docx.ts
+++ b/src/export/docx.ts
@@ -1,0 +1,11 @@
+import { Document, Packer, Paragraph, TextRun } from 'docx'
+import type { Segment } from '../providers/transcription/types'
+
+export async function textToDocx(text: string, segments?: Segment[]): Promise<Blob> {
+  const paragraphs = segments
+    ? segments.map((s) => new Paragraph({ children: [new TextRun(s.text.trim())] }))
+    : text.split(/\n\n+/).filter(Boolean).map((p) => new Paragraph({ children: [new TextRun(p)] }))
+
+  const doc = new Document({ sections: [{ children: paragraphs }] })
+  return Packer.toBlob(doc)
+}

--- a/src/export/srt.test.ts
+++ b/src/export/srt.test.ts
@@ -1,0 +1,32 @@
+import { segmentsToSrt } from './srt'
+import { EXAMPLE_SEGMENTS } from './__fixtures__/example-transcript'
+
+const EXPECTED_SRT =
+`1
+00:00:00,000 --> 00:00:02,500
+Hallo und willkommen.
+
+2
+00:00:02,500 --> 00:00:05,800
+Das ist ein Testsatz.
+
+3
+00:00:05,800 --> 00:00:09,420
+Noch ein dritter.
+`
+
+describe('segmentsToSrt', () => {
+  it('renders segments as SRT', () => {
+    expect(segmentsToSrt(EXAMPLE_SEGMENTS)).toBe(EXPECTED_SRT)
+  })
+
+  it('returns empty string for empty segments', () => {
+    expect(segmentsToSrt([])).toBe('')
+  })
+
+  it('trims whitespace from segment text', () => {
+    const result = segmentsToSrt([{ start: 0, end: 1, text: '  Hallo  ' }])
+    expect(result).toContain('Hallo\n')
+    expect(result).not.toContain('  Hallo  ')
+  })
+})

--- a/src/export/srt.ts
+++ b/src/export/srt.ts
@@ -1,0 +1,21 @@
+import type { Segment } from '../providers/transcription/types'
+
+function pad(n: number, digits: number): string {
+  return String(n).padStart(digits, '0')
+}
+
+function formatSrtTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  const ms = Math.round((seconds % 1) * 1000)
+  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)},${pad(ms, 3)}`
+}
+
+export function segmentsToSrt(segments: Segment[]): string {
+  return segments
+    .map((seg, i) =>
+      `${i + 1}\n${formatSrtTime(seg.start)} --> ${formatSrtTime(seg.end)}\n${seg.text.trim()}\n`
+    )
+    .join('\n')
+}

--- a/src/export/vtt.test.ts
+++ b/src/export/vtt.test.ts
@@ -1,0 +1,31 @@
+import { segmentsToVtt } from './vtt'
+import { EXAMPLE_SEGMENTS } from './__fixtures__/example-transcript'
+
+const EXPECTED_VTT =
+`WEBVTT
+
+00:00:00.000 --> 00:00:02.500
+Hallo und willkommen.
+
+00:00:02.500 --> 00:00:05.800
+Das ist ein Testsatz.
+
+00:00:05.800 --> 00:00:09.420
+Noch ein dritter.
+`
+
+describe('segmentsToVtt', () => {
+  it('renders segments as VTT with WEBVTT header', () => {
+    expect(segmentsToVtt(EXAMPLE_SEGMENTS)).toBe(EXPECTED_VTT)
+  })
+
+  it('uses dot as millisecond separator (not comma)', () => {
+    const result = segmentsToVtt([{ start: 1.5, end: 2.0, text: 'Test' }])
+    expect(result).toContain('00:00:01.500')
+    expect(result).not.toContain('00:00:01,500')
+  })
+
+  it('returns only header for empty segments', () => {
+    expect(segmentsToVtt([])).toBe('WEBVTT\n\n')
+  })
+})

--- a/src/export/vtt.ts
+++ b/src/export/vtt.ts
@@ -1,0 +1,22 @@
+import type { Segment } from '../providers/transcription/types'
+
+function pad(n: number, digits: number): string {
+  return String(n).padStart(digits, '0')
+}
+
+function formatVttTime(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
+  const s = Math.floor(seconds % 60)
+  const ms = Math.round((seconds % 1) * 1000)
+  return `${pad(h, 2)}:${pad(m, 2)}:${pad(s, 2)}.${pad(ms, 3)}`
+}
+
+export function segmentsToVtt(segments: Segment[]): string {
+  const cues = segments
+    .map(
+      (seg) => `${formatVttTime(seg.start)} --> ${formatVttTime(seg.end)}\n${seg.text.trim()}\n`
+    )
+    .join('\n')
+  return `WEBVTT\n\n${cues}`
+}

--- a/src/providers/transcription/groq.test.ts
+++ b/src/providers/transcription/groq.test.ts
@@ -29,6 +29,41 @@ describe('Groq Transcription Provider', () => {
     expect(call[1].headers.Authorization).toBe('Bearer gsk_test')
   })
 
+  it('maps segments from verbose_json response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        text: 'Hallo Welt',
+        language: 'de',
+        duration: 3.5,
+        segments: [
+          { start: 0, end: 1.5, text: 'Hallo', extra: 'ignored' },
+          { start: 1.5, end: 3.5, text: 'Welt', extra: 'ignored' },
+        ],
+      }),
+    })
+
+    const provider = createGroqProvider('gsk_test')
+    const result = await provider.transcribe(new Blob(['audio']), { language: 'de' })
+
+    expect(result.segments).toEqual([
+      { start: 0, end: 1.5, text: 'Hallo' },
+      { start: 1.5, end: 3.5, text: 'Welt' },
+    ])
+  })
+
+  it('returns undefined segments when not present in response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ text: 'Hallo Welt', language: 'de', duration: 3.5 }),
+    })
+
+    const provider = createGroqProvider('gsk_test')
+    const result = await provider.transcribe(new Blob(['audio']), { language: 'de' })
+
+    expect(result.segments).toBeUndefined()
+  })
+
   it('uses whisper-large-v3 model by default', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/src/providers/transcription/groq.ts
+++ b/src/providers/transcription/groq.ts
@@ -27,6 +27,13 @@ export function createGroqProvider(apiKey: string): TranscriptionProvider {
         text: data.text,
         language: data.language ?? options.language,
         duration: data.duration ?? 0,
+        segments: Array.isArray(data.segments)
+          ? data.segments.map((s: { start: number; end: number; text: string }) => ({
+              start: s.start,
+              end: s.end,
+              text: s.text,
+            }))
+          : undefined,
       }
     },
   }

--- a/src/providers/transcription/openai-whisper.test.ts
+++ b/src/providers/transcription/openai-whisper.test.ts
@@ -26,6 +26,41 @@ describe('OpenAI Whisper Transcription Provider', () => {
     )
   })
 
+  it('maps segments from verbose_json response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        text: 'Hello World',
+        language: 'en',
+        duration: 2.0,
+        segments: [
+          { start: 0, end: 1.0, text: 'Hello', extra: 'ignored' },
+          { start: 1.0, end: 2.0, text: 'World', extra: 'ignored' },
+        ],
+      }),
+    })
+
+    const provider = createOpenAIWhisperProvider('sk-test')
+    const result = await provider.transcribe(new Blob(['audio']), { language: 'de' })
+
+    expect(result.segments).toEqual([
+      { start: 0, end: 1.0, text: 'Hello' },
+      { start: 1.0, end: 2.0, text: 'World' },
+    ])
+  })
+
+  it('returns undefined segments when not present in response', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: async () => ({ text: 'Hello World', language: 'en', duration: 2.0 }),
+    })
+
+    const provider = createOpenAIWhisperProvider('sk-test')
+    const result = await provider.transcribe(new Blob(['audio']), { language: 'de' })
+
+    expect(result.segments).toBeUndefined()
+  })
+
   it('uses whisper-1 model by default', async () => {
     (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,

--- a/src/providers/transcription/openai-whisper.ts
+++ b/src/providers/transcription/openai-whisper.ts
@@ -27,6 +27,13 @@ export function createOpenAIWhisperProvider(apiKey: string): TranscriptionProvid
         text: data.text,
         language: data.language ?? options.language,
         duration: data.duration ?? 0,
+        segments: Array.isArray(data.segments)
+          ? data.segments.map((s: { start: number; end: number; text: string }) => ({
+              start: s.start,
+              end: s.end,
+              text: s.text,
+            }))
+          : undefined,
       }
     },
   }

--- a/src/providers/transcription/types.ts
+++ b/src/providers/transcription/types.ts
@@ -3,10 +3,17 @@ export interface TranscriptionOptions {
   model?: string;
 }
 
+export interface Segment {
+  start: number;
+  end: number;
+  text: string;
+}
+
 export interface TranscriptionResult {
   text: string;
   language: string;
   duration: number;
+  segments?: Segment[];
 }
 
 export interface TranscriptionProvider {


### PR DESCRIPTION
Closes #8. Includes S2 (segment timestamps + click-to-seek player) as prerequisite.

## Changes

**Segment timestamps (S2)**
- `Segment { start, end, text }` interface added to `TranscriptionResult` type
- Both providers (Groq, Whisper) now map `segments[]` from `verbose_json` response
- New `AudioPlayer` component renders native controls above the result panel for both mic recordings and file uploads
- Raw tab in `TranscriptionResult` renders clickable segment spans; clicking seeks the player; active segment highlighted with lemon tint

**SRT / VTT / DOCX export (S3)**
- New `src/export/srt.ts` — `segmentsToSrt()`, SRT format with `HH:MM:SS,mmm` timestamps
- New `src/export/vtt.ts` — `segmentsToVtt()`, WebVTT format with `HH:MM:SS.mmm` timestamps
- New `src/export/docx.ts` — `textToDocx()` via `docx` library, client-only, no upload
- `ExportBar`: three new buttons (`.srt`, `.vtt`, `.docx`); `.srt`/`.vtt` disabled without segments, `.docx` always available with flat-text fallback
- `downloadFile` helper extended to accept `string | Blob` for binary DOCX output

**Tests**
- 19 new tests: provider segment mapping, SRT/VTT string-equality against shared fixture, DOCX smoke test, ExportBar disabled states, TranscriptionResult click-to-seek + active highlight
- All assertions use `toBe`/`toEqual` inline — no snapshot files (consistent with `docs/testing.md`)

## Test plan

- [ ] `npx vitest run` — 148 passing, 1 pre-existing failure (`LandingPage` text mismatch on `main`)
- [ ] `npm run build` — clean tsc + vite build
- [ ] Dev server: mic recording → player appears, segments clickable, click seeks, active segment highlights
- [ ] File upload → same behaviour
- [ ] `.srt` / `.vtt` download → open in VLC/subtitle editor
- [ ] `.docx` download → open in Word/Pages
- [ ] No segments (future provider without `verbose_json`): `.srt`/`.vtt` disabled, `.docx` works