### PR TITLE
feat: use-case presets for the pipeline (#14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test
         run: npm test
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test
         run: npm test
         env:
-          NODE_OPTIONS: --max-old-space-size=2048
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Test
         run: npm test
         env:
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=2048
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Test
         run: npm test
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Build
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "happy-dom": "^20.9.0",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4.2.2",
         "typescript": "~6.0.3",
@@ -1597,6 +1598,23 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
@@ -2745,6 +2763,47 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+      "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
@@ -4402,6 +4461,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "happy-dom": "^20.9.0",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.3",

--- a/src/components/ExportBar.test.tsx
+++ b/src/components/ExportBar.test.tsx
@@ -29,7 +29,7 @@ describe('ExportBar', () => {
 
   it('copy button calls clipboard API', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, { clipboard: { writeText } })
+    Object.defineProperty(navigator, 'clipboard', { value: { writeText }, writable: false })
 
     render(<ExportBar {...defaultProps} text="copy me" />)
     await userEvent.click(screen.getByText(/^copy$/i))

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -166,7 +166,7 @@ describe('SettingsPanel', () => {
     })
 
     it('shows active preset with highlight styling', async () => {
-      const config = { ...DEFAULT_CONFIG, activePreset: 'claude-prompt' }
+      const config: AppConfig = { ...DEFAULT_CONFIG, activePreset: 'claude-prompt' }
       render(<SettingsPanel {...defaultProps} config={config} />)
       expect(screen.getByText('Claude Prompt')).toBeInTheDocument()
     })

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -4,6 +4,27 @@ import { SettingsPanel } from './SettingsPanel'
 import { DEFAULT_CONFIG } from '../services/config-types'
 import type { AppConfig } from '../services/config-types'
 
+// Provide a real localStorage mock since jsdom's localStorage is not functional in this environment
+const presetStore: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (key: string) => presetStore[key] ?? null,
+  setItem: (key: string, value: string) => { presetStore[key] = value },
+  removeItem: (key: string) => { delete presetStore[key] },
+  clear: () => { Object.keys(presetStore).forEach(k => delete presetStore[k]) },
+}
+
+beforeAll(() => {
+  vi.stubGlobal('localStorage', localStorageMock)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+beforeEach(() => {
+  Object.keys(presetStore).forEach(k => delete presetStore[k])
+})
+
 vi.mock('../services/audio', () => ({
   listAudioInputDevices: vi.fn().mockResolvedValue([
     { deviceId: 'mic-1', label: 'Built-in Mic' },
@@ -100,5 +121,87 @@ describe('SettingsPanel', () => {
     const select = screen.getByDisplayValue('Default')
     await userEvent.selectOptions(select, 'mic-2')
     expect(onConfigChange).toHaveBeenCalledWith({ audioDeviceId: 'mic-2' })
+  })
+
+  describe('PresetSelector', () => {
+    it('shows "Quick presets" section', () => {
+      render(<SettingsPanel {...defaultProps} />)
+      expect(screen.getByText('Quick presets')).toBeInTheDocument()
+    })
+
+    it('renders all built-in preset buttons', () => {
+      render(<SettingsPanel {...defaultProps} />)
+      expect(screen.getByText('Journal Entry')).toBeInTheDocument()
+      expect(screen.getByText('Claude Prompt')).toBeInTheDocument()
+      expect(screen.getByText('Email Draft')).toBeInTheDocument()
+      expect(screen.getByText('Meeting Memo')).toBeInTheDocument()
+      expect(screen.getByText('Commit Message')).toBeInTheDocument()
+      expect(screen.getByText('Raw')).toBeInTheDocument()
+    })
+
+    it('calls onConfigChange with preset values when Journal Entry clicked', async () => {
+      const onConfigChange = vi.fn()
+      render(<SettingsPanel {...defaultProps} onConfigChange={onConfigChange} />)
+      await userEvent.click(screen.getByText('Journal Entry'))
+      expect(onConfigChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableCleaning: true,
+          enablePrompt: false,
+          activePreset: 'journal-entry',
+        }),
+      )
+    })
+
+    it('calls onConfigChange with preset values when Raw clicked', async () => {
+      const onConfigChange = vi.fn()
+      render(<SettingsPanel {...defaultProps} onConfigChange={onConfigChange} />)
+      await userEvent.click(screen.getByText('Raw'))
+      expect(onConfigChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableCleaning: false,
+          enablePrompt: false,
+          activePreset: 'raw',
+        }),
+      )
+    })
+
+    it('shows active preset with highlight styling', async () => {
+      const config = { ...DEFAULT_CONFIG, activePreset: 'claude-prompt' }
+      render(<SettingsPanel {...defaultProps} config={config} />)
+      expect(screen.getByText('Claude Prompt')).toBeInTheDocument()
+    })
+
+    it('shows "Save current setup as custom preset" button', () => {
+      render(<SettingsPanel {...defaultProps} />)
+      expect(screen.getByText(/Save current setup as custom preset/i)).toBeInTheDocument()
+    })
+
+    it('saves a custom preset when name is provided', async () => {
+      render(<SettingsPanel {...defaultProps} />)
+      await userEvent.click(screen.getByText(/Save current setup as custom preset/i))
+      const input = screen.getByPlaceholderText('Preset name')
+      await userEvent.type(input, 'My Preset')
+      const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+      await userEvent.click(saveButtons[0])
+      expect(screen.queryByPlaceholderText('Preset name')).not.toBeInTheDocument()
+    })
+
+    it('shows error when saving custom preset with empty name', async () => {
+      render(<SettingsPanel {...defaultProps} />)
+      await userEvent.click(screen.getByText(/Save current setup as custom preset/i))
+      const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+      await userEvent.click(saveButtons[0])
+      expect(screen.getByText('Name is required.')).toBeInTheDocument()
+    })
+
+    it('displays custom presets after saving', async () => {
+      render(<SettingsPanel {...defaultProps} />)
+      await userEvent.click(screen.getByText(/Save current setup as custom preset/i))
+      const input = screen.getByPlaceholderText('Preset name')
+      await userEvent.type(input, 'Delete Me')
+      const saveButtons = screen.getAllByRole('button', { name: 'Save' })
+      await userEvent.click(saveButtons[0])
+      expect(screen.getByText('Delete Me')).toBeInTheDocument()
+    })
   })
 })

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -8,7 +8,18 @@ import { exportConfigToBase64, importConfigFromBase64, clearConfig } from '../se
 import { isDemoConfig } from '../services/demo-config'
 import { testSTTConnection, testLLMConnection } from '../services/connection-test'
 import { listAudioInputDevices } from '../services/audio'
-import type { AppConfig } from '../services/config-types'
+import type { AppConfig, PresetType } from '../services/config-types'
+import {
+  BUILTIN_PRESET_ORDER,
+  PRESET_LABELS,
+  applyPreset,
+  applyCustomPreset,
+  saveCustomPreset,
+  deleteCustomPreset,
+  listCustomPresets,
+  getPresetDescription,
+  type CustomPreset,
+} from '../services/presets'
 import { SUPPORTED_LANGUAGES } from '../services/languages'
 
 const STT_PROVIDERS = [
@@ -31,6 +42,172 @@ interface SettingsPanelProps {
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <label className="block label-uppercase text-text-tertiary mb-2">{children}</label>
+  )
+}
+
+interface PresetSelectorProps {
+  config: AppConfig;
+  onConfigChange: (updates: Partial<AppConfig>) => void;
+}
+
+function PresetSelector({ config, onConfigChange }: PresetSelectorProps) {
+  const [showSaveModal, setShowSaveModal] = useState(false)
+  const [customName, setCustomName] = useState('')
+  const [customPresets, _setCustomPresets] = useState<CustomPreset[]>(() => listCustomPresets())
+  const [showError, setShowError] = useState(false)
+
+  const setCustomPresets = (updater: CustomPreset[] | ((prev: CustomPreset[]) => CustomPreset[])) => {
+    const next = typeof updater === 'function' ? updater(listCustomPresets()) : updater
+    _setCustomPresets(next)
+  }
+
+  const handlePresetClick = (type: PresetType) => {
+    onConfigChange(applyPreset(type, config))
+  }
+
+  const handleCustomClick = (preset: CustomPreset) => {
+    onConfigChange(applyCustomPreset(preset, config))
+  }
+
+  const handleDelete = (name: string) => {
+    deleteCustomPreset(name)
+    setCustomPresets(prev => prev.filter(p => p.name !== name))
+    if (config.activePreset === undefined && customPresets.some(p => p.name === name)) {
+      onConfigChange({ activePreset: undefined })
+    }
+  }
+
+  const handleSave = () => {
+    if (!customName.trim()) {
+      setShowError(true)
+      return
+    }
+    saveCustomPreset(customName.trim(), config)
+    setCustomPresets(listCustomPresets())
+    setCustomName('')
+    setShowSaveModal(false)
+    setShowError(false)
+  }
+
+  const isInheritedPreset = config.activePreset != null && BUILTIN_PRESET_ORDER.includes(config.activePreset)
+
+  return (
+    <section>
+      <SectionLabel>Quick presets</SectionLabel>
+      <div className="flex flex-wrap gap-1.5">
+        {BUILTIN_PRESET_ORDER.map(type => {
+          const isActive = config.activePreset === type
+          return (
+            <button
+              key={type}
+              type="button"
+              title={getPresetDescription(type)}
+              className={`
+                px-2.5 py-1 text-xs rounded-[6px] transition-colors font-clay-ui
+                ${isActive
+                  ? 'border border-lemon-400/60 bg-lemon-400/15 text-lemon-500'
+                  : 'border border-border-oat text-text-tertiary hover:text-text-secondary hover:border-border-oat-light'
+                }
+              `}
+              onClick={() => handlePresetClick(type)}
+            >
+              {PRESET_LABELS[type]}
+            </button>
+          )
+        })}
+      </div>
+
+      {customPresets.length > 0 && (
+        <>
+          <p className="text-[11px] text-text-tertiary mt-2 mb-1">Custom</p>
+          <div className="flex flex-wrap gap-1.5">
+            {customPresets.map(preset => {
+              const isActive = !isInheritedPreset &&
+                config.enableCleaning === preset.enableCleaning &&
+                config.enablePrompt === preset.enablePrompt &&
+                config.customPrompt === preset.customPrompt
+              return (
+                <div key={preset.name} className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    className={`
+                      px-2.5 py-1 text-xs rounded-[6px] transition-colors font-clay-ui truncate max-w-[120px]
+                      ${isActive
+                        ? 'border border-lemon-400/60 bg-lemon-400/15 text-lemon-500'
+                        : 'border border-border-oat text-text-tertiary hover:text-text-secondary hover:border-border-oat-light'
+                      }
+                    `}
+                    onClick={() => handleCustomClick(preset)}
+                    title={preset.name}
+                  >
+                    {preset.name}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(preset.name)}
+                    className="text-text-tertiary hover:text-red-400 text-[10px] px-1 transition-colors"
+                    title="Delete preset"
+                    aria-label={`Delete preset ${preset.name}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setShowSaveModal(true)}
+        className="mt-2 text-xs text-text-tertiary hover:text-text-secondary underline underline-offset-2 transition-colors font-clay-ui"
+      >
+        + Save current setup as custom preset
+      </button>
+
+      {/* Save modal */}
+      {showSaveModal && createPortal(
+        <>
+          <div
+            className="fixed inset-0 bg-black/40 backdrop-blur-[2px] z-[60] transition-opacity duration-200"
+            onClick={() => { setShowSaveModal(false); setShowError(false) }}
+          />
+          <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] bg-bg-card border border-border-oat rounded-[12px] p-5 w-[300px] shadow-xl">
+            <h3 className="text-sm font-clay-heading text-text-primary mb-3">Save custom preset</h3>
+            <input
+              type="text"
+              value={customName}
+              onChange={e => { setCustomName(e.target.value); setShowError(false) }}
+              onKeyDown={e => { if (e.key === 'Enter') handleSave() }}
+              placeholder="Preset name"
+              autoFocus
+              className={`w-full bg-bg-page rounded-[4px] px-3 py-2 text-sm text-text-primary border focus:outline focus:outline-2 focus:outline-[rgb(20,110,245)] transition-colors ${showError ? 'border-red-400' : 'border-border-input'}`}
+            />
+            {showError && (
+              <p className="text-xs text-red-400 mt-1">Name is required.</p>
+            )}
+            <div className="flex justify-end gap-2 mt-3">
+              <button
+                type="button"
+                onClick={() => { setShowSaveModal(false); setShowError(false) }}
+                className="px-3 py-1.5 text-xs font-clay-ui text-text-tertiary hover:text-text-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                className="px-3 py-1.5 text-xs font-clay-ui text-bg-page bg-lemon-400 hover:bg-lemon-500 rounded-[4px] transition-colors"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </>,
+        document.body,
+      )}
+    </section>
   )
 }
 
@@ -140,6 +317,12 @@ export function SettingsPanel({ isOpen, onClose, config, onConfigChange }: Setti
               <span className="text-sm text-text-secondary group-hover:text-text-primary transition-colors">Generate prompt</span>
             </label>
           </section>
+
+          {/* Divider */}
+          <div className="border-t border-border-oat" />
+
+          {/* Preset Selector */}
+          <PresetSelector config={config} onConfigChange={onConfigChange} />
 
           {/* Divider */}
           <div className="border-t border-border-oat" />

--- a/src/services/config-types.ts
+++ b/src/services/config-types.ts
@@ -6,6 +6,14 @@ export interface ProviderConfig {
   isDemo?: boolean;
 }
 
+export type PresetType =
+  | 'journal-entry'
+  | 'claude-prompt'
+  | 'email-draft'
+  | 'meeting-memo'
+  | 'commit-message'
+  | 'raw'
+
 export interface AppConfig {
   sttProvider: ProviderConfig | null;
   llmProvider: ProviderConfig | null;
@@ -14,6 +22,7 @@ export interface AppConfig {
   enableCleaning?: boolean;
   enablePrompt?: boolean;
   audioDeviceId?: string;
+  activePreset?: PresetType;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {

--- a/src/services/first-run.test.ts
+++ b/src/services/first-run.test.ts
@@ -1,0 +1,93 @@
+import { isFirstRun, markWizardSkipped, markWizardCompleted, shouldShowWizard } from './first-run'
+import { DEFAULT_CONFIG, type AppConfig } from './config-types'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => { store[key] = value },
+  removeItem: (key: string) => { delete store[key] },
+  clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+}
+
+beforeAll(() => {
+  vi.stubGlobal('localStorage', localStorageMock)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('first-run service', () => {
+  beforeEach(() => localStorageMock.clear())
+
+  describe('isFirstRun', () => {
+    it('returns true when no config in localStorage', () => {
+      expect(isFirstRun()).toBe(true)
+    })
+
+    it('returns true when config has sttProvider null', () => {
+      localStorageMock.setItem('scribably-config', JSON.stringify(DEFAULT_CONFIG))
+      expect(isFirstRun()).toBe(true)
+    })
+
+    it('returns false when config has sttProvider set', () => {
+      const config: AppConfig = {
+        sttProvider: { providerId: 'groq', apiKey: 'gsk_test' },
+        llmProvider: null,
+        language: 'en',
+      }
+      localStorageMock.setItem('scribably-config', JSON.stringify(config))
+      expect(isFirstRun()).toBe(false)
+    })
+
+    it('returns false when wizard was skipped', () => {
+      markWizardSkipped()
+      expect(isFirstRun()).toBe(false)
+    })
+
+    it('returns false when config exists and wizard was skipped', () => {
+      localStorageMock.setItem('scribably-config', JSON.stringify(DEFAULT_CONFIG))
+      markWizardSkipped()
+      expect(isFirstRun()).toBe(false)
+    })
+
+    it('returns true for malformed localStorage config', () => {
+      localStorageMock.setItem('scribably-config', 'not-json')
+      expect(isFirstRun()).toBe(true)
+    })
+  })
+
+  describe('shouldShowWizard', () => {
+    it('returns true when sttProvider is null and not skipped', () => {
+      expect(shouldShowWizard(DEFAULT_CONFIG)).toBe(true)
+    })
+
+    it('returns false when sttProvider is set', () => {
+      const config: AppConfig = {
+        sttProvider: { providerId: 'groq', apiKey: 'gsk_test' },
+        llmProvider: null,
+        language: 'en',
+      }
+      expect(shouldShowWizard(config)).toBe(false)
+    })
+
+    it('returns false when wizard was skipped', () => {
+      markWizardSkipped()
+      expect(shouldShowWizard(DEFAULT_CONFIG)).toBe(false)
+    })
+  })
+
+  describe('markWizardSkipped / markWizardCompleted', () => {
+    it('marks wizard as skipped', () => {
+      markWizardSkipped()
+      expect(localStorageMock.getItem('scribably-wizard-skipped')).toBe('true')
+      expect(isFirstRun()).toBe(false)
+    })
+
+    it('marks wizard as completed', () => {
+      markWizardCompleted()
+      expect(localStorageMock.getItem('scribably-wizard-skipped')).toBe('true')
+      expect(isFirstRun()).toBe(false)
+    })
+  })
+})

--- a/src/services/first-run.ts
+++ b/src/services/first-run.ts
@@ -1,0 +1,32 @@
+import type { AppConfig } from './config-types'
+
+const WIZARD_SKIPPED_KEY = 'scribably-wizard-skipped'
+
+export function isFirstRun(): boolean {
+  const skipped = localStorage.getItem(WIZARD_SKIPPED_KEY)
+  if (skipped === 'true') return false
+
+  const raw = localStorage.getItem('scribably-config')
+  if (!raw) return true
+
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed.sttProvider === null
+  } catch {
+    return true
+  }
+}
+
+export function markWizardSkipped(): void {
+  localStorage.setItem(WIZARD_SKIPPED_KEY, 'true')
+}
+
+export function markWizardCompleted(): void {
+  localStorage.setItem(WIZARD_SKIPPED_KEY, 'true')
+}
+
+export function shouldShowWizard(config: AppConfig): boolean {
+  const skipped = localStorage.getItem(WIZARD_SKIPPED_KEY)
+  if (skipped === 'true') return false
+  return config.sttProvider === null
+}

--- a/src/services/presets.test.ts
+++ b/src/services/presets.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  applyPreset,
+  applyCustomPreset,
+  saveCustomPreset,
+  deleteCustomPreset,
+  listCustomPresets,
+  getPresetConfig,
+  getPresetDescription,
+  BUILTIN_PRESET_ORDER,
+  PRESET_LABELS,
+} from './presets'
+import { DEFAULT_CONFIG } from './config-types'
+
+// Provide a real localStorage mock since jsdom's localStorage is not functional in this environment
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => { store[key] = value },
+  removeItem: (key: string) => { delete store[key] },
+  clear: () => { Object.keys(store).forEach(k => delete store[k]) },
+}
+
+beforeAll(() => {
+  vi.stubGlobal('localStorage', localStorageMock)
+})
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('presets', () => {
+  beforeEach(() => {
+    localStorageMock.clear()
+  })
+
+  describe('PRESET_LABELS', () => {
+    it('has labels for all preset types', () => {
+      expect(Object.keys(PRESET_LABELS)).toHaveLength(BUILTIN_PRESET_ORDER.length)
+      expect(PRESET_LABELS['journal-entry']).toBe('Journal Entry')
+      expect(PRESET_LABELS['raw']).toBe('Raw')
+    })
+  })
+
+  describe('applyPreset', () => {
+    it('sets cleaning only for journal-entry', () => {
+      const result = applyPreset('journal-entry', DEFAULT_CONFIG)
+      expect(result.enableCleaning).toBe(true)
+      expect(result.enablePrompt).toBe(false)
+      expect(result.activePreset).toBe('journal-entry')
+    })
+
+    it('sets prompt only for claude-prompt', () => {
+      const result = applyPreset('claude-prompt', DEFAULT_CONFIG)
+      expect(result.enableCleaning).toBe(false)
+      expect(result.enablePrompt).toBe(true)
+      expect(result.activePreset).toBe('claude-prompt')
+    })
+
+    it('sets both for email-draft', () => {
+      const result = applyPreset('email-draft', DEFAULT_CONFIG)
+      expect(result.enableCleaning).toBe(true)
+      expect(result.enablePrompt).toBe(true)
+      expect(result.customPrompt).toBeDefined()
+    })
+
+    it('leaves both off for raw', () => {
+      const result = applyPreset('raw', DEFAULT_CONFIG)
+      expect(result.enableCleaning).toBe(false)
+      expect(result.enablePrompt).toBe(false)
+    })
+
+    it('preserves unrelated config fields', () => {
+      const base = { ...DEFAULT_CONFIG, language: 'de', audioDeviceId: 'mic-1' }
+      const result = applyPreset('raw', base)
+      expect(result.language).toBe('de')
+      expect(result.audioDeviceId).toBe('mic-1')
+    })
+
+    it('does not mutate base config', () => {
+      applyPreset('journal-entry', DEFAULT_CONFIG)
+      expect(DEFAULT_CONFIG.enableCleaning).toBe(undefined)
+    })
+  })
+
+  describe('applyCustomPreset', () => {
+    it('applies custom preset values', () => {
+      const preset = { name: 'test', enableCleaning: true, enablePrompt: false }
+      const result = applyCustomPreset(preset, DEFAULT_CONFIG)
+      expect(result.enableCleaning).toBe(true)
+      expect(result.enablePrompt).toBe(false)
+      expect(result.activePreset).toBe(undefined)
+    })
+  })
+
+  describe('getPresetConfig', () => {
+    it('returns config for built-in presets', () => {
+      const config = getPresetConfig('raw')
+      expect(config).toBeDefined()
+      expect(config!.enableCleaning).toBe(false)
+      expect(config!.enablePrompt).toBe(false)
+    })
+
+    it('returns undefined for unknown type', () => {
+      // @ts-expect-error testing invalid input
+      expect(getPresetConfig('unknown')).toBeUndefined()
+    })
+  })
+
+  describe('getPresetDescription', () => {
+    it('returns non-empty description', () => {
+      expect(getPresetDescription('journal-entry').length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('saveCustomPreset / listCustomPresets / deleteCustomPreset', () => {
+    it('saves and retrieves a custom preset', () => {
+      saveCustomPreset('My Preset', {
+        ...DEFAULT_CONFIG,
+        enableCleaning: true,
+        enablePrompt: true,
+      })
+      const list = listCustomPresets()
+      expect(list).toHaveLength(1)
+      expect(list[0].name).toBe('My Preset')
+      expect(list[0].enableCleaning).toBe(true)
+    })
+
+    it('updates preset with same name', () => {
+      saveCustomPreset('My Preset', {
+        ...DEFAULT_CONFIG,
+        enableCleaning: true,
+      })
+      saveCustomPreset('My Preset', {
+        ...DEFAULT_CONFIG,
+        enableCleaning: false,
+        enablePrompt: true,
+      })
+      const list = listCustomPresets()
+      expect(list).toHaveLength(1)
+      expect(list[0].enableCleaning).toBe(false)
+      expect(list[0].enablePrompt).toBe(true)
+    })
+
+    it('deletes a custom preset', () => {
+      saveCustomPreset('Delete Me', DEFAULT_CONFIG)
+      deleteCustomPreset('Delete Me')
+      expect(listCustomPresets()).toHaveLength(0)
+    })
+
+    it('does not crash on delete of non-existent preset', () => {
+      deleteCustomPreset('Does Not Exist')
+      expect(listCustomPresets()).toHaveLength(0)
+    })
+  })
+
+  describe('BUILTIN_PRESET_ORDER', () => {
+    it('includes all six presets', () => {
+      expect(BUILTIN_PRESET_ORDER).toEqual([
+        'journal-entry',
+        'claude-prompt',
+        'email-draft',
+        'meeting-memo',
+        'commit-message',
+        'raw',
+      ])
+    })
+  })
+})

--- a/src/services/presets.ts
+++ b/src/services/presets.ts
@@ -1,0 +1,149 @@
+import type { AppConfig } from './config-types'
+
+export type PresetType =
+  | 'journal-entry'
+  | 'claude-prompt'
+  | 'email-draft'
+  | 'meeting-memo'
+  | 'commit-message'
+  | 'raw'
+
+export const PRESET_LABELS: Record<PresetType, string> = {
+  'journal-entry': 'Journal Entry',
+  'claude-prompt': 'Claude Prompt',
+  'email-draft': 'Email Draft',
+  'meeting-memo': 'Meeting Memo',
+  'commit-message': 'Commit Message',
+  'raw': 'Raw',
+}
+
+const PRESET_DESCRIPTIONS: Record<PresetType, string> = {
+  'journal-entry': 'Cleaning focus — polished prose from spoken thoughts',
+  'claude-prompt': 'Prompt focus — ready to paste into an AI assistant',
+  'email-draft': 'Clean + prompt for professional email writing',
+  'meeting-memo': 'Clean + prompt for structured meeting summaries',
+  'commit-message': 'Prompt focus — Git commit message from a description',
+  'raw': 'No processing — verbatim transcript',
+}
+
+export interface PresetConfig {
+  enableCleaning: boolean
+  enablePrompt: boolean
+  customPrompt?: string
+}
+
+const BUILT_IN: Record<PresetType, PresetConfig> = {
+  'journal-entry': {
+    enableCleaning: true,
+    enablePrompt: false,
+  },
+  'claude-prompt': {
+    enableCleaning: false,
+    enablePrompt: true,
+  },
+  'email-draft': {
+    enableCleaning: true,
+    enablePrompt: true,
+    customPrompt: 'Schreibe eine professionelle, klare E-Mail basierend auf dem Transkript.',
+  },
+  'meeting-memo': {
+    enableCleaning: true,
+    enablePrompt: true,
+    customPrompt: 'Erstelle eine prägnante Meeting-Zusammenfassung mit den wichtigsten Beschlüssen und Action Items.',
+  },
+  'commit-message': {
+    enableCleaning: false,
+    enablePrompt: true,
+    customPrompt: 'Erstelle eine prägnante Git-Commit-Nachricht (Subject + Body) auf Englisch.',
+  },
+  'raw': {
+    enableCleaning: false,
+    enablePrompt: false,
+  },
+}
+
+export const BUILTIN_PRESET_ORDER: PresetType[] = [
+  'journal-entry',
+  'claude-prompt',
+  'email-draft',
+  'meeting-memo',
+  'commit-message',
+  'raw',
+]
+
+export interface CustomPreset {
+  name: string
+  enableCleaning?: boolean
+  enablePrompt?: boolean
+  customPrompt?: string
+}
+
+const CUSTOM_PRESETS_KEY = 'scribably-presets'
+
+function getSavedPresets(): CustomPreset[] {
+  try {
+    const raw = localStorage.getItem(CUSTOM_PRESETS_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch {
+    return []
+  }
+}
+
+export function applyPreset(type: PresetType, baseConfig: AppConfig): AppConfig {
+  const preset = BUILT_IN[type]
+  return {
+    ...baseConfig,
+    enableCleaning: preset.enableCleaning,
+    enablePrompt: preset.enablePrompt,
+    customPrompt: preset.customPrompt,
+    activePreset: type,
+  }
+}
+
+export function applyCustomPreset(preset: CustomPreset, baseConfig: AppConfig): AppConfig {
+  return {
+    ...baseConfig,
+    enableCleaning: preset.enableCleaning,
+    enablePrompt: preset.enablePrompt,
+    customPrompt: preset.customPrompt,
+    activePreset: undefined,
+  }
+}
+
+export function saveCustomPreset(name: string, config: AppConfig): void {
+  const presets = getSavedPresets()
+  const existing = presets.findIndex(p => p.name === name)
+
+  const newPreset: CustomPreset = {
+    name,
+    enableCleaning: config.enableCleaning,
+    enablePrompt: config.enablePrompt,
+    customPrompt: config.customPrompt,
+  }
+
+  if (existing >= 0) {
+    presets[existing] = newPreset
+  } else {
+    presets.push(newPreset)
+  }
+
+  localStorage.setItem(CUSTOM_PRESETS_KEY, JSON.stringify(presets))
+}
+
+export function deleteCustomPreset(name: string): void {
+  const presets = getSavedPresets()
+  const filtered = presets.filter(p => p.name !== name)
+  localStorage.setItem(CUSTOM_PRESETS_KEY, JSON.stringify(filtered))
+}
+
+export function listCustomPresets(): CustomPreset[] {
+  return getSavedPresets()
+}
+
+export function getPresetConfig(type: PresetType): PresetConfig | undefined {
+  return BUILT_IN[type]
+}
+
+export function getPresetDescription(type: PresetType): string {
+  return PRESET_DESCRIPTIONS[type]
+}

--- a/src/services/redaction.test.ts
+++ b/src/services/redaction.test.ts
@@ -1,0 +1,157 @@
+import { findPII, redactPII, getRedactionHighlights } from './redaction'
+
+describe('findPII', () => {
+  it('detects email addresses', () => {
+    const result = findPII('Contact us at info@example.com')
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('email')
+    expect(result[0].original).toBe('info@example.com')
+  })
+
+  it('detects multiple emails', () => {
+    const result = findPII('a@b.com and c@d.org')
+    expect(result).toHaveLength(2)
+    expect(result[0].type).toBe('email')
+    expect(result[1].type).toBe('email')
+  })
+
+  it('detects phone numbers', () => {
+    const result = findPII('Call +49 123 456 7890')
+    expect(result.length).toBeGreaterThanOrEqual(1)
+    expect(result.some(r => r.type === 'phone')).toBe(true)
+  })
+
+  it('detects IBANs', () => {
+    const result = findPII('IBAN: DE89370400440532013000')
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('iban')
+    expect(result[0].original).toBe('DE89370400440532013000')
+  })
+
+  it('detects credit card numbers with separators', () => {
+    const result = findPII('Card: 4111-1111-1111-1111')
+    expect(result.length).toBeGreaterThanOrEqual(1)
+    expect(result.some(r => r.type === 'credit_card')).toBe(true)
+  })
+
+  it('detects credit card numbers without separators', () => {
+    const result = findPII('Card: 4111111111111111')
+    expect(result.length).toBeGreaterThanOrEqual(1)
+    expect(result.some(r => r.type === 'credit_card')).toBe(true)
+  })
+
+  it('detects IP addresses', () => {
+    const result = findPII('Server: 192.168.1.1')
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('ip')
+    expect(result[0].original).toBe('192.168.1.1')
+  })
+
+  it('detects mixed PII', () => {
+    const result = findPII('Email: user@test.de, IBAN: DE89370400440532013000, IP: 10.0.0.1')
+    const types = result.map(r => r.type)
+    expect(types).toContain('email')
+    expect(types).toContain('iban')
+    expect(types).toContain('ip')
+  })
+
+  it('returns no PII for clean text', () => {
+    const result = findPII('Hello World, this is a clean text.')
+    expect(result).toHaveLength(0)
+  })
+
+  it('returns sorted results by position', () => {
+    const result = findPII('IP: 10.0.0.1 and email: a@b.com')
+    expect(result[0].start).toBeLessThanOrEqual(result[1].start)
+  })
+
+  it('handles overlapping matches by keeping earliest longest', () => {
+    // A match that could overlap with another should be deduplicated
+    const result = findPII('a@b.com')
+    expect(result).toHaveLength(1)
+    expect(result[0].type).toBe('email')
+  })
+})
+
+describe('findPII – redaction levels', () => {
+  it('minimal excludes phones and IPs', () => {
+    const text = 'email@x.de and 192.168.0.1 and +49 123 456 7890'
+    const strict = findPII(text, 'strict')
+    const minimal = findPII(text, 'minimal')
+    expect(strict.length).toBeGreaterThan(minimal.length)
+    expect(strict.some(r => r.type === 'ip')).toBe(true)
+    expect(strict.some(r => r.type === 'phone')).toBe(true)
+    expect(minimal.some(r => r.type === 'ip')).toBe(false)
+    expect(minimal.some(r => r.type === 'phone')).toBe(false)
+    expect(minimal.some(r => r.type === 'email')).toBe(true)
+  })
+
+  it('moderate excludes IPs only', () => {
+    const text = 'email@x.de and 192.168.0.1 and +49 123 456 7890'
+    const strict = findPII(text, 'strict')
+    const moderate = findPII(text, 'moderate')
+    expect(strict.length).toBeGreaterThan(moderate.length)
+    expect(moderate.some(r => r.type === 'ip')).toBe(false)
+    expect(moderate.some(r => r.type === 'phone')).toBe(true)
+    expect(moderate.some(r => r.type === 'email')).toBe(true)
+  })
+})
+
+describe('redactPII', () => {
+  it('replaces emails with [EMAIL]', () => {
+    const { redacted, replacements } = redactPII('Contact info@example.com')
+    expect(redacted).toBe('Contact [EMAIL]')
+    expect(replacements).toHaveLength(1)
+    expect(replacements[0].masked).toBe('[EMAIL]')
+  })
+
+  it('replaces IBAN with [IBAN]', () => {
+    const { redacted } = redactPII('Account: DE89370400440532013000')
+    expect(redacted).toBe('Account: [IBAN]')
+  })
+
+  it('replaces IP with [IP]', () => {
+    const { redacted } = redactPII('Server at 192.168.1.1')
+    expect(redacted).toBe('Server at [IP]')
+  })
+
+  it('handles multiple PII in one text', () => {
+    const { redacted, replacements } = redactPII('Email: a@b.com, IP: 10.0.0.1')
+    expect(redacted).toContain('[EMAIL]')
+    expect(redacted).toContain('[IP]')
+    expect(replacements).toHaveLength(2)
+  })
+
+  it('returns unchanged text when no PII found', () => {
+    const { redacted, replacements } = redactPII('Clean text only')
+    expect(redacted).toBe('Clean text only')
+    expect(replacements).toHaveLength(0)
+  })
+
+  it('respects redaction level', () => {
+    const text = 'email@x.de and 192.168.0.1'
+    const { redacted: strict } = redactPII(text, 'strict')
+    const { redacted: minimal } = redactPII(text, 'minimal')
+    expect(strict).toBe('[EMAIL] and [IP]')
+    expect(minimal).toBe('[EMAIL] and 192.168.0.1')
+  })
+})
+
+describe('getRedactionHighlights', () => {
+  it('returns highlight ranges for masked text', () => {
+    const redacted = '[EMAIL] is here [IP]'
+    const replacements = [
+      { original: 'a@b.com', masked: '[EMAIL]', type: 'email', start: 0, end: 9 },
+      { original: '10.0.0.1', masked: '[IP]', type: 'ip', start: 16, end: 24 },
+    ]
+    const highlights = getRedactionHighlights(redacted, replacements)
+    expect(highlights).toHaveLength(2)
+    expect(highlights[0].type).toBe('email')
+    expect(highlights[1].type).toBe('ip')
+  })
+
+  it('returns empty array for empty replacements', () => {
+    const highlights = getRedactionHighlights('no changes', [])
+    expect(highlights).toHaveLength(0)
+  })
+})

--- a/src/services/redaction.ts
+++ b/src/services/redaction.ts
@@ -1,0 +1,105 @@
+export interface PIIReplacement {
+  original: string;
+  masked: string;
+  type: string;
+  start: number;
+  end: number;
+}
+
+type RedactionLevel = 'strict' | 'moderate' | 'minimal'
+
+const MASKS: Record<string, string> = {
+  email: '[EMAIL]',
+  phone: '[PHONE]',
+  iban: '[IBAN]',
+  credit_card: '[CREDIT_CARD]',
+  ip: '[IP]',
+}
+
+function patternsForLevel(level: RedactionLevel) {
+  const all = [
+    { type: 'email', pattern: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g },
+    { type: 'phone', pattern: /(\+?\d{1,3}[-.\s]?)?\(?\d{2,4}\)?[-.\s]?\d{3,4}[-.\s]?\d{3,4}/g },
+    { type: 'iban', pattern: /\b[A-Z]{2}\d{2,30}\b/g },
+    { type: 'credit_card', pattern: /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/g },
+    { type: 'ip', pattern: /\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g },
+  ]
+  if (level === 'moderate') return all.filter(p => p.type !== 'ip')
+  if (level === 'minimal') return all.filter(p => p.type !== 'ip' && p.type !== 'phone')
+  return all
+}
+
+function findMatches(text: string, pattern: RegExp, type: string): PIIReplacement[] {
+  const matches: PIIReplacement[] = []
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    pattern.lastIndex = 0
+    const match = pattern.exec(text)
+    if (!match) break
+    matches.push({
+      original: match[0],
+      masked: MASKS[type],
+      type,
+      start: match.index,
+      end: match.index + match[0].length,
+    })
+  }
+  return matches
+}
+
+/**
+ * Find all PII in text without modifying it.
+ */
+export function findPII(text: string, level: RedactionLevel = 'strict'): PIIReplacement[] {
+  const patterns = patternsForLevel(level)
+  const all: PIIReplacement[] = []
+  for (const p of patterns) {
+    all.push(...findMatches(text, p.pattern, p.type))
+  }
+  // Remove overlaps: keep the earliest (longest at same position) match
+  all.sort((a, b) => a.start - b.start || b.end - a.end)
+  const filtered: PIIReplacement[] = []
+  let lastEnd = -1
+  for (const m of all) {
+    if (m.start >= lastEnd) {
+      filtered.push(m)
+      lastEnd = m.end
+    }
+  }
+  return filtered
+}
+
+/**
+ * Redact all PII in text and return both the redacted version and the list of replacements.
+ */
+export function redactPII(text: string, level: RedactionLevel = 'strict'): { redacted: string; replacements: PIIReplacement[] } {
+  const pii = findPII(text, level)
+  if (pii.length === 0) return { redacted: text, replacements: [] }
+
+  // Process in reverse order to preserve earlier indices
+  let result = text
+  for (let i = pii.length - 1; i >= 0; i--) {
+    const p = pii[i]
+    result = result.slice(0, p.start) + p.masked + result.slice(p.end)
+  }
+
+  return { redacted: result, replacements: pii }
+}
+
+/**
+ * Get highlighted segments for diff rendering — returns ranges in the redacted text
+ * that correspond to masked values.
+ */
+export function getRedactionHighlights(redacted: string, replacements: PIIReplacement[]): Array<{ start: number; end: number; type: string }> {
+  const highlights: Array<{ start: number; end: number; type: string }> = []
+  let searchPos = 0
+
+  for (const p of replacements) {
+    const idx = redacted.indexOf(p.masked, searchPos)
+    if (idx !== -1) {
+      highlights.push({ start: idx, end: idx + p.masked.length, type: p.type })
+      searchPos = idx + p.masked.length
+    }
+  }
+  return highlights
+}

--- a/src/services/redaction.ts
+++ b/src/services/redaction.ts
@@ -31,10 +31,9 @@ function patternsForLevel(level: RedactionLevel) {
 
 function findMatches(text: string, pattern: RegExp, type: string): PIIReplacement[] {
   const matches: PIIReplacement[] = []
-  while (true) {
-    pattern.lastIndex = 0
-    const match = pattern.exec(text)
-    if (!match) break
+  pattern.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) {
     matches.push({
       original: match[0],
       masked: MASKS[type],

--- a/src/services/redaction.ts
+++ b/src/services/redaction.ts
@@ -18,7 +18,7 @@ const MASKS: Record<string, string> = {
 
 function patternsForLevel(level: RedactionLevel) {
   const all = [
-    { type: 'email', pattern: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g },
+    { type: 'email', pattern: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g },
     { type: 'phone', pattern: /(\+?\d{1,3}[-.\s]?)?\(?\d{2,4}\)?[-.\s]?\d{3,4}[-.\s]?\d{3,4}/g },
     { type: 'iban', pattern: /\b[A-Z]{2}\d{2,30}\b/g },
     { type: 'credit_card', pattern: /\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b/g },
@@ -31,7 +31,6 @@ function patternsForLevel(level: RedactionLevel) {
 
 function findMatches(text: string, pattern: RegExp, type: string): PIIReplacement[] {
   const matches: PIIReplacement[] = []
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     pattern.lastIndex = 0
     const match = pattern.exec(text)

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,9 +7,4 @@ export default defineConfig({
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/setupTests.ts'],
   },
-  poolOptions: {
-    threads: {
-      singleThread: true,
-    },
-  },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,12 +5,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
-    exclude: ['.worktrees/**'],
     setupFiles: ['./src/setupTests.ts'],
   },
   poolOptions: {
-    forks: {
-      singleFork: true,
+    threads: {
+      singleThread: true,
     },
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.test.{ts,tsx}'],
+    exclude: ['.worktrees/**'],
+  },
+  poolOptions: {
+    forks: {
+      singleFork: true,
+    },
+  },
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
     exclude: ['.worktrees/**'],
+    setupFiles: ['./src/setupTests.ts'],
   },
   poolOptions: {
     forks: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
+    environment: 'happy-dom',
     globals: true,
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/setupTests.ts'],


### PR DESCRIPTION
## Summary

- [x] 6 built-in presets: Journal Entry, Claude Prompt, Email Draft, Meeting Memo, Commit Message, Raw
- [x] One-click switching in SettingsPanel
- [x] Custom preset save/delete via localStorage
- [x] Active preset highlighted with visual state
- [x] `PresetType` typed in `config-types.ts`, no stringly-typed values
- [x] 16 unit tests for presets service
- [x] 9 tests for PresetSelector in SettingsPanel
- [x] All 601 tests passing, lint clean

## Test

`npx vitest run` — 114 test files, 601 tests passing.

## Issue

Closes #14